### PR TITLE
Enable syntax hightlighting for code blocks in the documentation

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -1,3 +1,6 @@
+markdown_extensions:
+  - pymdownx.highlight
+  - pymdownx.superfences
 site_name: My Docs
 site_url:
 theme:


### PR DESCRIPTION
Turns out, enabling it was not difficult as long as you can figure out it has to be enabled in the `mkdocs.yml` file.

See: https://squidfunk.github.io/mkdocs-material/reference/code-blocks/

----
Fixes #76