### PR TITLE
Fix incorrect trimming of keywords when used as key

### DIFF
--- a/src/mal/CBCore.cpp
+++ b/src/mal/CBCore.cpp
@@ -936,7 +936,8 @@ std::vector<malCBlockPtr> blockify(const malValuePtr &arg) {
     for (auto [k, v] : v->m_map) {
       auto cbv = varify(v);
       vars.emplace_back(cbv);
-      cbMap[unescape(k)] = cbv->value();
+      // key is either a quoted string or a keyword (starting with ':')
+      cbMap[k[0] == '"' ? unescape(k) : k.substr(1)] = cbv->value();
     }
     var.valueType = Table;
     var.payload.tableValue.api = &chainblocks::Globals::TableInterface;

--- a/src/mal/CBCore.cpp
+++ b/src/mal/CBCore.cpp
@@ -1017,7 +1017,8 @@ malCBVarPtr varify(const malValuePtr &arg) {
     for (auto [k, v] : v->m_map) {
       auto cbv = varify(v);
       vars.emplace_back(cbv);
-      cbMap[unescape(k)] = cbv->value();
+      // key is either a quoted string or a keyword (starting with ':')
+      cbMap[k[0] == '"' ? unescape(k) : k.substr(1)] = cbv->value();
     }
     CBVar tmp{};
     tmp.valueType = Table;


### PR DESCRIPTION
Keywords start with a ':' while simple keys are quoted strings.

When used as key in a map, quoted strings need to be "unescaped", and keywords need to only lose the leading ':' character.

Fixes #91