### PR TITLE
Update copyright notices in source code files

### DIFF
--- a/docker/linux/Dockerfile
+++ b/docker/linux/Dockerfile
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright © 2019 Fragcolor Pte. Ltd.
+
 FROM ubuntu:20.04
 
 ENV DEBIAN_FRONTEND=noninteractive

--- a/docker/linux/Dockerfile-alpine
+++ b/docker/linux/Dockerfile-alpine
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright © 2020 Fragcolor Pte. Ltd.
+
 FROM i386/alpine
 
 ENV DEBIAN_FRONTEND=noninteractive

--- a/docker/linux/Dockerfile-runtime
+++ b/docker/linux/Dockerfile-runtime
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright © 2020 Fragcolor Pte. Ltd.
+
 FROM ubuntu:20.04
 
 ENV DEBIAN_FRONTEND=noninteractive

--- a/docker/wasm/Dockerfile
+++ b/docker/wasm/Dockerfile
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright © 2019 Fragcolor Pte. Ltd.
+
 FROM archlinux/base
 
 RUN pacman -Syu --noconfirm && pacman -S --noconfirm base-devel git cmake wget clang ninja boost binaryen emscripten

--- a/examples/imgui-reload/imgui-sandbox.clj
+++ b/examples/imgui-reload/imgui-sandbox.clj
@@ -1,3 +1,6 @@
+; SPDX-License-Identifier: BSD-3-Clause
+; Copyright © 2019 Fragcolor Pte. Ltd.
+
 (do
   (Chain
    "Reloadable"

--- a/examples/imgui-reload/imgui-style.clj
+++ b/examples/imgui-reload/imgui-style.clj
@@ -1,3 +1,6 @@
+; SPDX-License-Identifier: BSD-3-Clause
+; Copyright © 2019 Fragcolor Pte. Ltd.
+
 (defn FColor
   [r g b a]
   (Color (* 255 r) (* 255 g) (* 255 b) (* 255 a)))

--- a/examples/imgui-reload/main.clj
+++ b/examples/imgui-reload/main.clj
@@ -1,3 +1,6 @@
+; SPDX-License-Identifier: BSD-3-Clause
+; Copyright © 2019 Fragcolor Pte. Ltd.
+
 (load-file "imgui-style.clj")
 
 (def Root (Node))

--- a/examples/shaderc/shaderc.clj
+++ b/examples/shaderc/shaderc.clj
@@ -1,3 +1,6 @@
+; SPDX-License-Identifier: BSD-3-Clause
+; Copyright © 2021 Fragcolor Pte. Ltd.
+
 (def shaders-platform
   (cond
     (= platform "windows") "windows"

--- a/include/blockwrapper.hpp
+++ b/include/blockwrapper.hpp
@@ -1,5 +1,5 @@
-/* SPDX-License-Identifier: BSD 3-Clause "New" or "Revised" License */
-/* Copyright © 2019-2021 Giovanni Petrantoni */
+/* SPDX-License-Identifier: BSD-3-Clause */
+/* Copyright © 2019 Fragcolor Pte. Ltd. */
 
 #ifndef CB_BLOCKWRAPPER_HPP
 #define CB_BLOCKWRAPPER_HPP

--- a/include/chain_dsl.hpp
+++ b/include/chain_dsl.hpp
@@ -1,5 +1,5 @@
-/* SPDX-License-Identifier: BSD 3-Clause "New" or "Revised" License */
-/* Copyright © 2021 Giovanni Petrantoni */
+/* SPDX-License-Identifier: BSD-3-Clause */
+/* Copyright © 2021 Fragcolor Pte. Ltd. */
 
 #ifndef CB_CHAIN_DSL_HPP
 #define CB_CHAIN_DSL_HPP

--- a/include/chainblocks.h
+++ b/include/chainblocks.h
@@ -1,5 +1,5 @@
-/* SPDX-License-Identifier: BSD 3-Clause "New" or "Revised" License */
-/* Copyright © 2019-2021 Giovanni Petrantoni */
+/* SPDX-License-Identifier: BSD-3-Clause */
+/* Copyright © 2019 Fragcolor Pte. Ltd. */
 
 #ifndef CB_CHAINBLOCKS_H
 #define CB_CHAINBLOCKS_H

--- a/include/chainblocks.hpp
+++ b/include/chainblocks.hpp
@@ -1,5 +1,5 @@
-/* SPDX-License-Identifier: BSD 3-Clause "New" or "Revised" License */
-/* Copyright © 2019-2021 Giovanni Petrantoni */
+/* SPDX-License-Identifier: BSD-3-Clause */
+/* Copyright © 2019 Fragcolor Pte. Ltd. */
 
 #ifndef CB_CHAINBLOCKS_HPP
 #define CB_CHAINBLOCKS_HPP

--- a/include/common_types.hpp
+++ b/include/common_types.hpp
@@ -1,5 +1,5 @@
-/* SPDX-License-Identifier: BSD 3-Clause "New" or "Revised" License */
-/* Copyright © 2019-2021 Giovanni Petrantoni */
+/* SPDX-License-Identifier: BSD-3-Clause */
+/* Copyright © 2019 Fragcolor Pte. Ltd. */
 
 /*
 Utility to auto load auto discover blocks from DLLs

--- a/include/dllblock.hpp
+++ b/include/dllblock.hpp
@@ -1,5 +1,5 @@
-/* SPDX-License-Identifier: BSD 3-Clause "New" or "Revised" License */
-/* Copyright © 2019-2021 Giovanni Petrantoni */
+/* SPDX-License-Identifier: BSD-3-Clause */
+/* Copyright © 2019 Fragcolor Pte. Ltd. */
 
 /*
 Utility to auto load auto discover blocks from DLLs

--- a/include/linalg_shim.hpp
+++ b/include/linalg_shim.hpp
@@ -1,5 +1,5 @@
-/* SPDX-License-Identifier: BSD 3-Clause "New" or "Revised" License */
-/* Copyright © 2021 Giovanni Petrantoni */
+/* SPDX-License-Identifier: BSD-3-Clause */
+/* Copyright © 2021 Fragcolor Pte. Ltd. */
 
 #ifndef CB_LINALG_SHIM_HPP
 #define CB_LINALG_SHIM_HPP

--- a/include/ops.hpp
+++ b/include/ops.hpp
@@ -1,5 +1,5 @@
-/* SPDX-License-Identifier: BSD 3-Clause "New" or "Revised" License */
-/* Copyright © 2019-2021 Giovanni Petrantoni */
+/* SPDX-License-Identifier: BSD-3-Clause */
+/* Copyright © 2019 Fragcolor Pte. Ltd. */
 
 #ifndef CB_OPS_HPP
 #define CB_OPS_HPP

--- a/include/utility.hpp
+++ b/include/utility.hpp
@@ -1,5 +1,5 @@
-/* SPDX-License-Identifier: BSD 3-Clause "New" or "Revised" License */
-/* Copyright © 2019-2021 Giovanni Petrantoni */
+/* SPDX-License-Identifier: BSD-3-Clause */
+/* Copyright © 2019 Fragcolor Pte. Ltd. */
 
 #ifndef CB_UTILITY_HPP
 #define CB_UTILITY_HPP

--- a/rust/build.rs
+++ b/rust/build.rs
@@ -1,3 +1,6 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+/* Copyright © 2020 Fragcolor Pte. Ltd. */
+
 #[cfg(feature = "run_bindgen")]
 extern crate bindgen;
 

--- a/rust/docker/Dockerfile
+++ b/rust/docker/Dockerfile
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright © 2020 Fragcolor Pte. Ltd.
+
 FROM archlinux/base
 
 RUN pacman -Syu --noconfirm && pacman -S --noconfirm base-devel git curl cmake wget clang ninja boost

--- a/rust/docker/run_linux.sh
+++ b/rust/docker/run_linux.sh
@@ -1,5 +1,8 @@
 #!/bin/sh
 
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright © 2019 Fragcolor Pte. Ltd.
+
 # fail on errors
 set -e
 

--- a/rust/src/block.rs
+++ b/rust/src/block.rs
@@ -1,3 +1,6 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+/* Copyright © 2020 Fragcolor Pte. Ltd. */
+
 use crate::chainblocksc::CBContext;
 use crate::chainblocksc::CBExposedTypesInfo;
 use crate::chainblocksc::CBInstanceData;

--- a/rust/src/blocks/browse.rs
+++ b/rust/src/blocks/browse.rs
@@ -1,3 +1,6 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+/* Copyright © 2021 Fragcolor Pte. Ltd. */
+
 use crate::block::Block;
 use crate::core::do_blocking;
 use crate::core::log;

--- a/rust/src/blocks/casting.rs
+++ b/rust/src/blocks/casting.rs
@@ -1,3 +1,6 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+/* Copyright © 2021 Fragcolor Pte. Ltd. */
+
 use crate::block::Block;
 use crate::core::do_blocking;
 use crate::core::log;

--- a/rust/src/blocks/ecdsa.rs
+++ b/rust/src/blocks/ecdsa.rs
@@ -1,3 +1,6 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+/* Copyright © 2021 Fragcolor Pte. Ltd. */
+
 use crate::block::Block;
 use crate::chainblocksc::CBType_String;
 use crate::core::do_blocking;

--- a/rust/src/blocks/eth.rs
+++ b/rust/src/blocks/eth.rs
@@ -1,3 +1,6 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+/* Copyright © 2021 Fragcolor Pte. Ltd. */
+
 use crate::block::Block;
 use crate::core::do_blocking;
 use crate::core::log;

--- a/rust/src/blocks/hash.rs
+++ b/rust/src/blocks/hash.rs
@@ -1,3 +1,6 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+/* Copyright © 2021 Fragcolor Pte. Ltd. */
+
 use crate::block::Block;
 use crate::core::do_blocking;
 use crate::core::log;

--- a/rust/src/blocks/http.rs
+++ b/rust/src/blocks/http.rs
@@ -1,3 +1,6 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+/* Copyright © 2020 Fragcolor Pte. Ltd. */
+
 use crate::block::Block;
 use crate::core::activate_blocking;
 use crate::core::do_blocking;

--- a/rust/src/blocks/mod.rs
+++ b/rust/src/blocks/mod.rs
@@ -1,3 +1,6 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+/* Copyright © 2020 Fragcolor Pte. Ltd. */
+
 #[cfg(not(target_arch = "wasm32"))]
 extern crate reqwest;
 

--- a/rust/src/blocks/physics/forces.rs
+++ b/rust/src/blocks/physics/forces.rs
@@ -1,3 +1,6 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+/* Copyright © 2021 Fragcolor Pte. Ltd. */
+
 use crate::blocks::physics::RigidBody;
 use crate::blocks::physics::Simulation;
 use crate::blocks::physics::EXPOSED_SIMULATION;

--- a/rust/src/blocks/physics/mod.rs
+++ b/rust/src/blocks/physics/mod.rs
@@ -1,3 +1,6 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+/* Copyright © 2021 Fragcolor Pte. Ltd. */
+
 extern crate crossbeam;
 extern crate rapier3d;
 

--- a/rust/src/blocks/physics/queries.rs
+++ b/rust/src/blocks/physics/queries.rs
@@ -1,3 +1,6 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+/* Copyright © 2021 Fragcolor Pte. Ltd. */
+
 use crate::blocks::physics::Simulation;
 use crate::blocks::physics::EXPOSED_SIMULATION;
 use crate::blocks::physics::RIGIDBODIES_TYPE;

--- a/rust/src/blocks/physics/rigidbody.rs
+++ b/rust/src/blocks/physics/rigidbody.rs
@@ -1,3 +1,6 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+/* Copyright © 2021 Fragcolor Pte. Ltd. */
+
 use crate::blocks::physics::fill_seq_from_mat4;
 use crate::blocks::physics::mat4_from_seq;
 use crate::blocks::physics::BaseShape;

--- a/rust/src/blocks/physics/shapes.rs
+++ b/rust/src/blocks/physics/shapes.rs
@@ -1,3 +1,6 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+/* Copyright © 2021 Fragcolor Pte. Ltd. */
+
 // RigidBody and Collier are unique, Shapes can be shared
 
 use crate::blocks::physics::BaseShape;

--- a/rust/src/blocks/physics/simulation.rs
+++ b/rust/src/blocks/physics/simulation.rs
@@ -1,3 +1,6 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+/* Copyright © 2021 Fragcolor Pte. Ltd. */
+
 use crate::blocks::physics::Simulation;
 use crate::blocks::physics::EXPOSED_SIMULATION;
 use crate::blocks::physics::SIMULATION_TYPE;

--- a/rust/src/blocks/svg.rs
+++ b/rust/src/blocks/svg.rs
@@ -1,3 +1,6 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+/* Copyright © 2021 Fragcolor Pte. Ltd. */
+
 use crate::chainblocksc::CBIMAGE_FLAGS_PREMULTIPLIED_ALPHA;
 use crate::block::Block;
 use crate::chainblocksc::CBImage;

--- a/rust/src/core.rs
+++ b/rust/src/core.rs
@@ -1,3 +1,6 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+/* Copyright © 2020 Fragcolor Pte. Ltd. */
+
 #![macro_use]
 
 use crate::block::cblock_construct;

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -1,3 +1,6 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+/* Copyright © 2020 Fragcolor Pte. Ltd. */
+
 #![allow(non_upper_case_globals)]
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]

--- a/rust/src/types.rs
+++ b/rust/src/types.rs
@@ -1,3 +1,6 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+/* Copyright © 2020 Fragcolor Pte. Ltd. */
+
 use crate::chainblocksc::CBBool;
 use crate::chainblocksc::CBChain;
 use crate::chainblocksc::CBChainState;

--- a/src/core/blocks/assert.cpp
+++ b/src/core/blocks/assert.cpp
@@ -1,5 +1,5 @@
-/* SPDX-License-Identifier: BSD 3-Clause "New" or "Revised" License */
-/* Copyright © 2019-2021 Giovanni Petrantoni */
+/* SPDX-License-Identifier: BSD-3-Clause */
+/* Copyright © 2019 Fragcolor Pte. Ltd. */
 
 #include "shared.hpp"
 

--- a/src/core/blocks/bigint.cpp
+++ b/src/core/blocks/bigint.cpp
@@ -1,5 +1,5 @@
-/* SPDX-License-Identifier: BSD 3-Clause "New" or "Revised" License */
-/* Copyright © 2019-2021 Giovanni Petrantoni */
+/* SPDX-License-Identifier: BSD-3-Clause */
+/* Copyright © 2020 Fragcolor Pte. Ltd. */
 
 #ifndef CB_NO_BIGINT_BLOCKS
 

--- a/src/core/blocks/casting.cpp
+++ b/src/core/blocks/casting.cpp
@@ -1,5 +1,5 @@
-/* SPDX-License-Identifier: BSD 3-Clause "New" or "Revised" License */
-/* Copyright © 2019-2021 Giovanni Petrantoni */
+/* SPDX-License-Identifier: BSD-3-Clause */
+/* Copyright © 2019 Fragcolor Pte. Ltd. */
 
 #include "shared.hpp"
 #include <boost/beast/core/detail/base64.hpp>

--- a/src/core/blocks/chains.cpp
+++ b/src/core/blocks/chains.cpp
@@ -1,5 +1,5 @@
-/* SPDX-License-Identifier: BSD 3-Clause "New" or "Revised" License */
-/* Copyright © 2019-2021 Giovanni Petrantoni */
+/* SPDX-License-Identifier: BSD-3-Clause */
+/* Copyright © 2019 Fragcolor Pte. Ltd. */
 
 #include "foundation.hpp"
 #include "shared.hpp"

--- a/src/core/blocks/channels.cpp
+++ b/src/core/blocks/channels.cpp
@@ -1,5 +1,5 @@
-/* SPDX-License-Identifier: BSD 3-Clause "New" or "Revised" License */
-/* Copyright © 2019-2021 Giovanni Petrantoni */
+/* SPDX-License-Identifier: BSD-3-Clause */
+/* Copyright © 2020 Fragcolor Pte. Ltd. */
 
 #include "shared.hpp"
 #include <atomic>

--- a/src/core/blocks/core.cpp
+++ b/src/core/blocks/core.cpp
@@ -1,5 +1,5 @@
-/* SPDX-License-Identifier: BSD 3-Clause "New" or "Revised" License */
-/* Copyright © 2019-2021 Giovanni Petrantoni */
+/* SPDX-License-Identifier: BSD-3-Clause */
+/* Copyright © 2019 Fragcolor Pte. Ltd. */
 
 #include "../runtime.hpp"
 #include "pdqsort.h"

--- a/src/core/blocks/core.hpp
+++ b/src/core/blocks/core.hpp
@@ -1,5 +1,5 @@
-/* SPDX-License-Identifier: BSD 3-Clause "New" or "Revised" License */
-/* Copyright © 2019-2021 Giovanni Petrantoni */
+/* SPDX-License-Identifier: BSD-3-Clause */
+/* Copyright © 2019 Fragcolor Pte. Ltd. */
 
 #pragma once
 

--- a/src/core/blocks/core.js
+++ b/src/core/blocks/core.js
@@ -1,5 +1,5 @@
-/* SPDX-License-Identifier: BSD 3-Clause "New" or "Revised" License */
-/* Copyright © 2021 Giovanni Petrantoni */
+/* SPDX-License-Identifier: BSD-3-Clause */
+/* Copyright © 2021 Fragcolor Pte. Ltd. */
 
 // emscripten related utilities
 

--- a/src/core/blocks/edn.cpp
+++ b/src/core/blocks/edn.cpp
@@ -1,5 +1,5 @@
-/* SPDX-License-Identifier: BSD 3-Clause "New" or "Revised" License */
-/* Copyright © 2019-2021 Giovanni Petrantoni */
+/* SPDX-License-Identifier: BSD-3-Clause */
+/* Copyright © 2021 Fragcolor Pte. Ltd. */
 
 #include "../edn/print.hpp"
 #include "../edn/read.hpp"

--- a/src/core/blocks/flow.cpp
+++ b/src/core/blocks/flow.cpp
@@ -1,5 +1,5 @@
-/* SPDX-License-Identifier: BSD 3-Clause "New" or "Revised" License */
-/* Copyright © 2019-2021 Giovanni Petrantoni */
+/* SPDX-License-Identifier: BSD-3-Clause */
+/* Copyright © 2019 Fragcolor Pte. Ltd. */
 
 #include "blockwrapper.hpp"
 #include "chainblocks.h"

--- a/src/core/blocks/fs.cpp
+++ b/src/core/blocks/fs.cpp
@@ -1,5 +1,5 @@
-/* SPDX-License-Identifier: BSD 3-Clause "New" or "Revised" License */
-/* Copyright © 2019-2021 Giovanni Petrantoni */
+/* SPDX-License-Identifier: BSD-3-Clause */
+/* Copyright © 2019 Fragcolor Pte. Ltd. */
 
 #include "shared.hpp"
 #include <boost/algorithm/string.hpp>

--- a/src/core/blocks/genetic.hpp
+++ b/src/core/blocks/genetic.hpp
@@ -1,3 +1,6 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+/* Copyright © 2021 Fragcolor Pte. Ltd. */
+
 #include "blockwrapper.hpp"
 #include "chainblocks.h"
 #include "chainblocks.hpp"

--- a/src/core/blocks/http.cpp
+++ b/src/core/blocks/http.cpp
@@ -1,5 +1,5 @@
-/* SPDX-License-Identifier: BSD 3-Clause "New" or "Revised" License */
-/* Copyright © 2019-2021 Giovanni Petrantoni */
+/* SPDX-License-Identifier: BSD-3-Clause */
+/* Copyright © 2020 Fragcolor Pte. Ltd. */
 
 #ifndef CB_NO_HTTP_BLOCKS
 

--- a/src/core/blocks/imaging.cpp
+++ b/src/core/blocks/imaging.cpp
@@ -1,3 +1,6 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+/* Copyright © 2020 Fragcolor Pte. Ltd. */
+
 #ifndef IMAGING_H
 #define IMAGING_H
 

--- a/src/core/blocks/json.cpp
+++ b/src/core/blocks/json.cpp
@@ -1,5 +1,5 @@
-/* SPDX-License-Identifier: BSD 3-Clause "New" or "Revised" License */
-/* Copyright © 2019-2021 Giovanni Petrantoni */
+/* SPDX-License-Identifier: BSD-3-Clause */
+/* Copyright © 2019 Fragcolor Pte. Ltd. */
 
 #include "nlohmann/json.hpp"
 #include "chainblocks.h"

--- a/src/core/blocks/linalg.cpp
+++ b/src/core/blocks/linalg.cpp
@@ -1,5 +1,5 @@
-/* SPDX-License-Identifier: BSD 3-Clause "New" or "Revised" License */
-/* Copyright © 2019-2021 Giovanni Petrantoni */
+/* SPDX-License-Identifier: BSD-3-Clause */
+/* Copyright © 2019 Fragcolor Pte. Ltd. */
 
 #include "math.h"
 #include "shared.hpp"

--- a/src/core/blocks/logging.cpp
+++ b/src/core/blocks/logging.cpp
@@ -1,5 +1,5 @@
-/* SPDX-License-Identifier: BSD 3-Clause "New" or "Revised" License */
-/* Copyright © 2019-2021 Giovanni Petrantoni */
+/* SPDX-License-Identifier: BSD-3-Clause */
+/* Copyright © 2019 Fragcolor Pte. Ltd. */
 
 #include "shared.hpp"
 #include <string>

--- a/src/core/blocks/math.hpp
+++ b/src/core/blocks/math.hpp
@@ -1,5 +1,5 @@
-/* SPDX-License-Identifier: BSD 3-Clause "New" or "Revised" License */
-/* Copyright © 2019-2021 Giovanni Petrantoni */
+/* SPDX-License-Identifier: BSD-3-Clause */
+/* Copyright © 2019 Fragcolor Pte. Ltd. */
 
 #pragma once
 

--- a/src/core/blocks/network.cpp
+++ b/src/core/blocks/network.cpp
@@ -1,5 +1,5 @@
-/* SPDX-License-Identifier: BSD 3-Clause "New" or "Revised" License */
-/* Copyright © 2019-2021 Giovanni Petrantoni */
+/* SPDX-License-Identifier: BSD-3-Clause */
+/* Copyright © 2019 Fragcolor Pte. Ltd. */
 
 // ASIO must go first!!
 #include <boost/asio.hpp>

--- a/src/core/blocks/os.cpp
+++ b/src/core/blocks/os.cpp
@@ -1,5 +1,5 @@
-/* SPDX-License-Identifier: BSD 3-Clause "New" or "Revised" License */
-/* Copyright © 2019-2021 Giovanni Petrantoni */
+/* SPDX-License-Identifier: BSD-3-Clause */
+/* Copyright © 2019 Fragcolor Pte. Ltd. */
 
 // #include "shared.hpp"
 // #include <boost/process/environment.hpp>

--- a/src/core/blocks/process.cpp
+++ b/src/core/blocks/process.cpp
@@ -1,5 +1,5 @@
-/* SPDX-License-Identifier: BSD 3-Clause "New" or "Revised" License */
-/* Copyright © 2019-2021 Giovanni Petrantoni */
+/* SPDX-License-Identifier: BSD-3-Clause */
+/* Copyright © 2019 Fragcolor Pte. Ltd. */
 
 #ifdef _WIN32
 #include "winsock2.h"

--- a/src/core/blocks/random.cpp
+++ b/src/core/blocks/random.cpp
@@ -1,5 +1,5 @@
-/* SPDX-License-Identifier: BSD 3-Clause "New" or "Revised" License */
-/* Copyright © 2019-2021 Giovanni Petrantoni */
+/* SPDX-License-Identifier: BSD-3-Clause */
+/* Copyright © 2020 Fragcolor Pte. Ltd. */
 
 #include "shared.hpp"
 #include <random>

--- a/src/core/blocks/reflection.cpp
+++ b/src/core/blocks/reflection.cpp
@@ -1,5 +1,5 @@
-/* SPDX-License-Identifier: BSD 3-Clause "New" or "Revised" License */
-/* Copyright © 2019-2021 Giovanni Petrantoni */
+/* SPDX-License-Identifier: BSD-3-Clause */
+/* Copyright © 2021 Fragcolor Pte. Ltd. */
 
 #include "shared.hpp"
 

--- a/src/core/blocks/seqs.cpp
+++ b/src/core/blocks/seqs.cpp
@@ -1,5 +1,5 @@
-/* SPDX-License-Identifier: BSD 3-Clause "New" or "Revised" License */
-/* Copyright © 2019-2021 Giovanni Petrantoni */
+/* SPDX-License-Identifier: BSD-3-Clause */
+/* Copyright © 2019 Fragcolor Pte. Ltd. */
 
 #include "shared.hpp"
 #include <unordered_set>

--- a/src/core/blocks/serialization.cpp
+++ b/src/core/blocks/serialization.cpp
@@ -1,5 +1,5 @@
-/* SPDX-License-Identifier: BSD 3-Clause "New" or "Revised" License */
-/* Copyright © 2019-2021 Giovanni Petrantoni */
+/* SPDX-License-Identifier: BSD-3-Clause */
+/* Copyright © 2019 Fragcolor Pte. Ltd. */
 
 #define STB_IMAGE_IMPLEMENTATION
 #define STB_IMAGE_WRITE_IMPLEMENTATION

--- a/src/core/blocks/shared.hpp
+++ b/src/core/blocks/shared.hpp
@@ -1,5 +1,5 @@
-/* SPDX-License-Identifier: BSD 3-Clause "New" or "Revised" License */
-/* Copyright © 2019-2021 Giovanni Petrantoni */
+/* SPDX-License-Identifier: BSD-3-Clause */
+/* Copyright © 2019 Fragcolor Pte. Ltd. */
 
 #ifndef CB_SHARED_HPP
 #define CB_SHARED_HPP

--- a/src/core/blocks/strings.cpp
+++ b/src/core/blocks/strings.cpp
@@ -1,5 +1,5 @@
-/* SPDX-License-Identifier: BSD 3-Clause "New" or "Revised" License */
-/* Copyright © 2019-2021 Giovanni Petrantoni */
+/* SPDX-License-Identifier: BSD-3-Clause */
+/* Copyright © 2019 Fragcolor Pte. Ltd. */
 
 #include "../../../deps/utf8.h/utf8.h"
 #include "shared.hpp"

--- a/src/core/blocks/struct.cpp
+++ b/src/core/blocks/struct.cpp
@@ -1,5 +1,5 @@
-/* SPDX-License-Identifier: BSD 3-Clause "New" or "Revised" License */
-/* Copyright © 2019-2021 Giovanni Petrantoni */
+/* SPDX-License-Identifier: BSD-3-Clause */
+/* Copyright © 2019 Fragcolor Pte. Ltd. */
 
 #include "shared.hpp"
 #include <regex>

--- a/src/core/blocks/time.cpp
+++ b/src/core/blocks/time.cpp
@@ -1,5 +1,5 @@
-/* SPDX-License-Identifier: BSD 3-Clause "New" or "Revised" License */
-/* Copyright © 2019-2021 Giovanni Petrantoni */
+/* SPDX-License-Identifier: BSD-3-Clause */
+/* Copyright © 2019 Fragcolor Pte. Ltd. */
 
 #include "shared.hpp"
 #include <chrono>

--- a/src/core/blocks/wasm.cpp
+++ b/src/core/blocks/wasm.cpp
@@ -1,5 +1,5 @@
-/* SPDX-License-Identifier: BSD 3-Clause "New" or "Revised" License */
-/* Copyright © 2019-2021 Giovanni Petrantoni */
+/* SPDX-License-Identifier: BSD-3-Clause */
+/* Copyright © 2020 Fragcolor Pte. Ltd. */
 
 #include "shared.hpp"
 #include <cstdio>

--- a/src/core/blocks/ws.cpp
+++ b/src/core/blocks/ws.cpp
@@ -1,5 +1,5 @@
-/* SPDX-License-Identifier: BSD 3-Clause "New" or "Revised" License */
-/* Copyright © 2019-2021 Giovanni Petrantoni */
+/* SPDX-License-Identifier: BSD-3-Clause */
+/* Copyright © 2020 Fragcolor Pte. Ltd. */
 
 #ifndef CB_NO_HTTP_BLOCKS
 #define BOOST_ERROR_CODE_HEADER_ONLY

--- a/src/core/blocks_macros.hpp
+++ b/src/core/blocks_macros.hpp
@@ -1,5 +1,5 @@
-/* SPDX-License-Identifier: BSD 3-Clause "New" or "Revised" License */
-/* Copyright © 2019-2021 Giovanni Petrantoni */
+/* SPDX-License-Identifier: BSD-3-Clause */
+/* Copyright © 2019 Fragcolor Pte. Ltd. */
 
 // TODO, get rid of this, use Blockswrapper
 

--- a/src/core/compress-strings.edn
+++ b/src/core/compress-strings.edn
@@ -1,3 +1,6 @@
+; SPDX-License-Identifier: BSD-3-Clause
+; Copyright © 2021 Fragcolor Pte. Ltd.
+
 ; we compress a cbl script that will populate the strings at runtime
 
 (def strings (export-strings))

--- a/src/core/coro.cpp
+++ b/src/core/coro.cpp
@@ -1,3 +1,6 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+/* Copyright © 2020 Fragcolor Pte. Ltd. */
+
 #include "foundation.hpp"
 
 thread_local emscripten_fiber_t *em_local_coro{nullptr};

--- a/src/core/edn/eval.cpp
+++ b/src/core/edn/eval.cpp
@@ -1,3 +1,6 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+/* Copyright © 2019 Fragcolor Pte. Ltd. */
+
 #include "eval.hpp"
 
 using namespace chainblocks::edn::eval;

--- a/src/core/edn/eval.hpp
+++ b/src/core/edn/eval.hpp
@@ -1,3 +1,6 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+/* Copyright © 2019 Fragcolor Pte. Ltd. */
+
 #ifndef CB_LSP_EVAL_HPP
 #define CB_LSP_EVAL_HPP
 

--- a/src/core/edn/main.cpp
+++ b/src/core/edn/main.cpp
@@ -1,3 +1,6 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+/* Copyright © 2020 Fragcolor Pte. Ltd. */
+
 #include "eval.hpp"
 #include "print.hpp"
 #include <string>

--- a/src/core/edn/print.hpp
+++ b/src/core/edn/print.hpp
@@ -1,5 +1,5 @@
-/* SPDX-License-Identifier: BSD 3-Clause "New" or "Revised" License */
-/* Copyright © 2019-2021 Giovanni Petrantoni */
+/* SPDX-License-Identifier: BSD-3-Clause */
+/* Copyright © 2019 Fragcolor Pte. Ltd. */
 
 // Derived from https://github.com/oakes/ZachLisp
 

--- a/src/core/edn/test.edn
+++ b/src/core/edn/test.edn
@@ -1,3 +1,6 @@
+; SPDX-License-Identifier: BSD-3-Clause
+; Copyright © 2020 Fragcolor Pte. Ltd.
+
 ;; (def Root (Node))
 ;; (def callme (fn [] Root))
 ;; (callme)

--- a/src/core/foundation.hpp
+++ b/src/core/foundation.hpp
@@ -1,5 +1,5 @@
-/* SPDX-License-Identifier: BSD 3-Clause "New" or "Revised" License */
-/* Copyright © 2019-2021 Giovanni Petrantoni */
+/* SPDX-License-Identifier: BSD-3-Clause */
+/* Copyright © 2019 Fragcolor Pte. Ltd. */
 
 #ifndef CB_CORE_HPP
 #define CB_CORE_HPP

--- a/src/core/ops_internal.cpp
+++ b/src/core/ops_internal.cpp
@@ -1,3 +1,6 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+/* Copyright © 2019 Fragcolor Pte. Ltd. */
+
 #include "ops_internal.hpp"
 #include "ops.hpp"
 #include <unordered_set>

--- a/src/core/ops_internal.hpp
+++ b/src/core/ops_internal.hpp
@@ -1,5 +1,5 @@
-/* SPDX-License-Identifier: BSD 3-Clause "New" or "Revised" License */
-/* Copyright © 2019-2021 Giovanni Petrantoni */
+/* SPDX-License-Identifier: BSD-3-Clause */
+/* Copyright © 2019 Fragcolor Pte. Ltd. */
 
 #ifndef CB_OPS_INTERNAL_HPP
 #define CB_OPS_INTERNAL_HPP

--- a/src/core/runtime.cpp
+++ b/src/core/runtime.cpp
@@ -1,5 +1,5 @@
-/* SPDX-License-Identifier: BSD 3-Clause "New" or "Revised" License */
-/* Copyright © 2019-2021 Giovanni Petrantoni */
+/* SPDX-License-Identifier: BSD-3-Clause */
+/* Copyright © 2019 Fragcolor Pte. Ltd. */
 
 #include "runtime.hpp"
 #include "blocks/shared.hpp"

--- a/src/core/runtime.hpp
+++ b/src/core/runtime.hpp
@@ -1,5 +1,5 @@
-/* SPDX-License-Identifier: BSD 3-Clause "New" or "Revised" License */
-/* Copyright © 2019-2021 Giovanni Petrantoni */
+/* SPDX-License-Identifier: BSD-3-Clause */
+/* Copyright © 2019 Fragcolor Pte. Ltd. */
 
 #ifndef CB_RUNTIME_HPP
 #define CB_RUNTIME_HPP

--- a/src/extra/audio.cpp
+++ b/src/extra/audio.cpp
@@ -1,5 +1,5 @@
-/* SPDX-License-Identifier: BSD 3-Clause "New" or "Revised" License */
-/* Copyright © 2021 Giovanni Petrantoni */
+/* SPDX-License-Identifier: BSD-3-Clause */
+/* Copyright © 2021 Fragcolor Pte. Ltd. */
 
 #include "blocks/shared.hpp"
 #include "runtime.hpp"

--- a/src/extra/audio.mm
+++ b/src/extra/audio.mm
@@ -1,3 +1,6 @@
+/* SPDX-License-Identifier: BSD 3-Clause "New" or "Revised" License */
+/* Copyright © 2021 Fragcolor Pte. Ltd. */
+
 // just a trick for iOS...
 
 #include "audio.cpp"

--- a/src/extra/bgfx.cpp
+++ b/src/extra/bgfx.cpp
@@ -1,5 +1,5 @@
-/* SPDX-License-Identifier: BSD 3-Clause "New" or "Revised" License */
-/* Copyright © 2019-2021 Giovanni Petrantoni */
+/* SPDX-License-Identifier: BSD-3-Clause */
+/* Copyright © 2019 Fragcolor Pte. Ltd. */
 
 #include "./bgfx.hpp"
 #include "./imgui.hpp"

--- a/src/extra/bgfx.hpp
+++ b/src/extra/bgfx.hpp
@@ -1,5 +1,5 @@
-/* SPDX-License-Identifier: BSD 3-Clause "New" or "Revised" License */
-/* Copyright © 2019-2021 Giovanni Petrantoni */
+/* SPDX-License-Identifier: BSD-3-Clause */
+/* Copyright © 2019 Fragcolor Pte. Ltd. */
 
 #ifndef CB_BGFX_HPP
 #define CB_BGFX_HPP

--- a/src/extra/bgfx.shaderc.cpp
+++ b/src/extra/bgfx.shaderc.cpp
@@ -1,5 +1,5 @@
-/* SPDX-License-Identifier: BSD 3-Clause "New" or "Revised" License */
-/* Copyright © 2021 Giovanni Petrantoni */
+/* SPDX-License-Identifier: BSD-3-Clause */
+/* Copyright © 2021 Fragcolor Pte. Ltd. */
 
 // collection of runtime chains to allow shader compilation, caching and
 // storage.

--- a/src/extra/bgfx.shaderc.js
+++ b/src/extra/bgfx.shaderc.js
@@ -1,5 +1,5 @@
-/* SPDX-License-Identifier: BSD 3-Clause "New" or "Revised" License */
-/* Copyright © 2021 Giovanni Petrantoni */
+/* SPDX-License-Identifier: BSD-3-Clause */
+/* Copyright © 2021 Fragcolor Pte. Ltd. */
 
 // emscripten related utilities
 

--- a/src/extra/bgfx_tests.cpp
+++ b/src/extra/bgfx_tests.cpp
@@ -1,5 +1,5 @@
-/* SPDX-License-Identifier: BSD 3-Clause "New" or "Revised" License */
-/* Copyright © 2019-2021 Giovanni Petrantoni */
+/* SPDX-License-Identifier: BSD-3-Clause */
+/* Copyright © 2020 Fragcolor Pte. Ltd. */
 
 // included in bgfx.cpp
 

--- a/src/extra/brotli.cpp
+++ b/src/extra/brotli.cpp
@@ -1,5 +1,5 @@
-/* SPDX-License-Identifier: BSD 3-Clause "New" or "Revised" License */
-/* Copyright © 2019-2021 Giovanni Petrantoni */
+/* SPDX-License-Identifier: BSD-3-Clause */
+/* Copyright © 2020 Fragcolor Pte. Ltd. */
 
 #include "blocks/shared.hpp"
 #include "runtime.hpp"

--- a/src/extra/desktop.capture.win.hpp
+++ b/src/extra/desktop.capture.win.hpp
@@ -1,5 +1,5 @@
-/* SPDX-License-Identifier: BSD 3-Clause "New" or "Revised" License */
-/* Copyright © 2019-2021 Giovanni Petrantoni */
+/* SPDX-License-Identifier: BSD-3-Clause */
+/* Copyright © 2019 Fragcolor Pte. Ltd. */
 
 #include "chainblocks.h"
 #include <D3Dcommon.h>

--- a/src/extra/desktop.hpp
+++ b/src/extra/desktop.hpp
@@ -1,5 +1,5 @@
-/* SPDX-License-Identifier: BSD 3-Clause "New" or "Revised" License */
-/* Copyright © 2019-2021 Giovanni Petrantoni */
+/* SPDX-License-Identifier: BSD-3-Clause */
+/* Copyright © 2019 Fragcolor Pte. Ltd. */
 
 #pragma once
 

--- a/src/extra/desktop.win.cpp
+++ b/src/extra/desktop.win.cpp
@@ -1,5 +1,5 @@
-/* SPDX-License-Identifier: BSD 3-Clause "New" or "Revised" License */
-/* Copyright © 2019-2021 Giovanni Petrantoni */
+/* SPDX-License-Identifier: BSD-3-Clause */
+/* Copyright © 2019 Fragcolor Pte. Ltd. */
 
 #define WINVER 0x0602
 

--- a/src/extra/dsp.cpp
+++ b/src/extra/dsp.cpp
@@ -1,5 +1,5 @@
-/* SPDX-License-Identifier: BSD 3-Clause "New" or "Revised" License */
-/* Copyright © 2021 Giovanni Petrantoni */
+/* SPDX-License-Identifier: BSD-3-Clause */
+/* Copyright © 2021 Fragcolor Pte. Ltd. */
 
 #include "blocks/shared.hpp"
 #include "runtime.hpp"

--- a/src/extra/gltf.cpp
+++ b/src/extra/gltf.cpp
@@ -1,5 +1,5 @@
-/* SPDX-License-Identifier: BSD 3-Clause "New" or "Revised" License */
-/* Copyright © 2021 Giovanni Petrantoni */
+/* SPDX-License-Identifier: BSD-3-Clause */
+/* Copyright © 2021 Fragcolor Pte. Ltd. */
 
 #include "./bgfx.hpp"
 #include "blocks/shared.hpp"

--- a/src/extra/gltf_tests.cpp
+++ b/src/extra/gltf_tests.cpp
@@ -1,5 +1,5 @@
-/* SPDX-License-Identifier: BSD 3-Clause "New" or "Revised" License */
-/* Copyright © 2021 Giovanni Petrantoni */
+/* SPDX-License-Identifier: BSD-3-Clause */
+/* Copyright © 2021 Fragcolor Pte. Ltd. */
 
 // included in gltf.cpp
 

--- a/src/extra/imgui.cpp
+++ b/src/extra/imgui.cpp
@@ -1,5 +1,5 @@
-/* SPDX-License-Identifier: BSD 3-Clause "New" or "Revised" License */
-/* Copyright © 2019-2021 Giovanni Petrantoni */
+/* SPDX-License-Identifier: BSD-3-Clause */
+/* Copyright © 2019 Fragcolor Pte. Ltd. */
 
 #include "imgui.hpp"
 #include "bgfx.hpp"

--- a/src/extra/imgui.hpp
+++ b/src/extra/imgui.hpp
@@ -1,5 +1,5 @@
-/* SPDX-License-Identifier: BSD 3-Clause "New" or "Revised" License */
-/* Copyright © 2019-2021 Giovanni Petrantoni */
+/* SPDX-License-Identifier: BSD-3-Clause */
+/* Copyright © 2019 Fragcolor Pte. Ltd. */
 
 #pragma once
 

--- a/src/extra/inputs.cpp
+++ b/src/extra/inputs.cpp
@@ -1,5 +1,5 @@
-/* SPDX-License-Identifier: BSD 3-Clause "New" or "Revised" License */
-/* Copyright © 2021 Giovanni Petrantoni */
+/* SPDX-License-Identifier: BSD-3-Clause */
+/* Copyright © 2021 Fragcolor Pte. Ltd. */
 
 #include "./bgfx.hpp"
 #include "SDL.h"

--- a/src/extra/runtime.cpp
+++ b/src/extra/runtime.cpp
@@ -1,5 +1,5 @@
-/* SPDX-License-Identifier: BSD 3-Clause "New" or "Revised" License */
-/* Copyright © 2019-2021 Giovanni Petrantoni */
+/* SPDX-License-Identifier: BSD-3-Clause */
+/* Copyright © 2019 Fragcolor Pte. Ltd. */
 
 #include "runtime.hpp"
 

--- a/src/extra/shaders/gltf/ps_entry.h
+++ b/src/extra/shaders/gltf/ps_entry.h
@@ -1,7 +1,7 @@
 $input v_normal, v_tangent, v_bitangent, v_texcoord0, v_texcoord1, v_color0, v_wpos, v_view
 
-/* SPDX-License-Identifier: BSD 3-Clause "New" or "Revised" License */
-/* Copyright © 2021 Giovanni Petrantoni */
+/* SPDX-License-Identifier: BSD-3-Clause */
+/* Copyright © 2021 Fragcolor Pte. Ltd. */
 
 #include <bgfx_shader.h>
 #include <shaderlib.h>

--- a/src/extra/shaders/gltf/vs_entry.h
+++ b/src/extra/shaders/gltf/vs_entry.h
@@ -1,8 +1,8 @@
 $input a_position, a_normal, a_tangent, a_texcoord0, a_texcoord1, a_color0, i_data0, i_data1, i_data2, i_data3
 $output v_normal, v_tangent, v_bitangent, v_texcoord0, v_texcoord1, v_color0, v_wpos, v_view
 
-/* SPDX-License-Identifier: BSD 3-Clause "New" or "Revised" License */
-/* Copyright © 2021 Giovanni Petrantoni */
+/* SPDX-License-Identifier: BSD-3-Clause */
+/* Copyright © 2021 Fragcolor Pte. Ltd. */
 
 #include <bgfx_shader.h>
 #include <shaderlib.h>

--- a/src/extra/shaders/include/shader.h
+++ b/src/extra/shaders/include/shader.h
@@ -1,5 +1,5 @@
-/* SPDX-License-Identifier: BSD 3-Clause "New" or "Revised" License */
-/* Copyright © 2021 Giovanni Petrantoni */
+/* SPDX-License-Identifier: BSD-3-Clause */
+/* Copyright © 2021 Fragcolor Pte. Ltd. */
 
 #ifndef CB_SHADER_H
 #define CB_SHADER_H

--- a/src/extra/snappy.cpp
+++ b/src/extra/snappy.cpp
@@ -1,5 +1,5 @@
-/* SPDX-License-Identifier: BSD 3-Clause "New" or "Revised" License */
-/* Copyright © 2019-2021 Giovanni Petrantoni */
+/* SPDX-License-Identifier: BSD-3-Clause */
+/* Copyright © 2019 Fragcolor Pte. Ltd. */
 
 #include "blocks/shared.hpp"
 #include "runtime.hpp"

--- a/src/extra/xr.cpp
+++ b/src/extra/xr.cpp
@@ -1,5 +1,5 @@
-/* SPDX-License-Identifier: BSD 3-Clause "New" or "Revised" License */
-/* Copyright © 2021 Giovanni Petrantoni */
+/* SPDX-License-Identifier: BSD-3-Clause */
+/* Copyright © 2021 Fragcolor Pte. Ltd. */
 
 #include "./bgfx.hpp"
 #include "blocks/shared.hpp"

--- a/src/mal/CBCore.cpp
+++ b/src/mal/CBCore.cpp
@@ -1,5 +1,5 @@
-/* SPDX-License-Identifier: BSD 3-Clause "New" or "Revised" License */
-/* Copyright © 2019-2021 Giovanni Petrantoni */
+/* SPDX-License-Identifier: MPL-2.0 AND BSD-3-Clause */
+/* Copyright © 2019 Fragcolor Pte. Ltd. */
 
 #include "chainblocks.hpp"
 #define String MalString

--- a/src/mal/Core.cpp
+++ b/src/mal/Core.cpp
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: MPL-2.0 */
+/* Copyright © 2019 Fragcolor Pte. Ltd. */
+/* Copyright (C) 2015 Joel Martin <github@martintribe.org> */
+
 #include "Environment.h"
 #include "MAL.h"
 #include "StaticList.h"

--- a/src/mal/Debug.h
+++ b/src/mal/Debug.h
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: MPL-2.0 */
+/* Copyright © 2020 Fragcolor Pte. Ltd. */
+/* Copyright (C) 2015 Joel Martin <github@martintribe.org> */
+
 #ifndef INCLUDE_DEBUG_H
 #define INCLUDE_DEBUG_H
 

--- a/src/mal/Environment.cpp
+++ b/src/mal/Environment.cpp
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: MPL-2.0 */
+/* Copyright © 2020 Fragcolor Pte. Ltd. */
+/* Copyright (C) 2015 Joel Martin <github@martintribe.org> */
+
 #include "Environment.h"
 #include "Types.h"
 

--- a/src/mal/Environment.h
+++ b/src/mal/Environment.h
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: MPL-2.0 */
+/* Copyright © 2019 Fragcolor Pte. Ltd. */
+/* Copyright (C) 2015 Joel Martin <github@martintribe.org> */
+
 #ifndef INCLUDE_ENVIRONMENT_H
 #define INCLUDE_ENVIRONMENT_H
 

--- a/src/mal/MAL.h
+++ b/src/mal/MAL.h
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: MPL-2.0 */
+/* Copyright © 2019 Fragcolor Pte. Ltd. */
+/* Copyright (C) 2015 Joel Martin <github@martintribe.org> */
+
 #ifndef INCLUDE_MAL_H
 #define INCLUDE_MAL_H
 

--- a/src/mal/ReadLine.cpp
+++ b/src/mal/ReadLine.cpp
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: MPL-2.0 */
+/* Copyright © 2020 Fragcolor Pte. Ltd. */
+/* Copyright (C) 2015 Joel Martin <github@martintribe.org> */
+
 #include "ReadLine.h"
 #include "String.h"
 #include <replxx.hxx>

--- a/src/mal/ReadLine.h
+++ b/src/mal/ReadLine.h
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: MPL-2.0 */
+/* Copyright © 2020 Fragcolor Pte. Ltd. */
+/* Copyright (C) 2015 Joel Martin <github@martintribe.org> */
+
 #ifndef INCLUDE_READLINE_H
 #define INCLUDE_READLINE_H
 

--- a/src/mal/Reader.cpp
+++ b/src/mal/Reader.cpp
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: MPL-2.0 */
+/* Copyright © 2019 Fragcolor Pte. Ltd. */
+/* Copyright (C) 2015 Joel Martin <github@martintribe.org> */
+
 #include "MAL.h"
 #include "Types.h"
 

--- a/src/mal/RefCountedPtr.h
+++ b/src/mal/RefCountedPtr.h
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: MPL-2.0 */
+/* Copyright © 2020 Fragcolor Pte. Ltd. */
+/* Copyright (C) 2015 Joel Martin <github@martintribe.org> */
+
 #ifndef INCLUDE_REFCOUNTEDPTR_H
 #define INCLUDE_REFCOUNTEDPTR_H
 

--- a/src/mal/StaticList.h
+++ b/src/mal/StaticList.h
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: MPL-2.0 */
+/* Copyright © 2020 Fragcolor Pte. Ltd. */
+/* Copyright (C) 2015 Joel Martin <github@martintribe.org> */
+
 #ifndef INCLUDE_STATICLIST_H
 #define INCLUDE_STATICLIST_H
 

--- a/src/mal/String.cpp
+++ b/src/mal/String.cpp
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: MPL-2.0 */
+/* Copyright © 2020 Fragcolor Pte. Ltd. */
+/* Copyright (C) 2015 Joel Martin <github@martintribe.org> */
+
 #include "String.h"
 #include "Debug.h"
 

--- a/src/mal/String.h
+++ b/src/mal/String.h
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: MPL-2.0 */
+/* Copyright © 2020 Fragcolor Pte. Ltd. */
+/* Copyright (C) 2015 Joel Martin <github@martintribe.org> */
+
 #ifndef INCLUDE_STRING_H
 #define INCLUDE_STRING_H
 

--- a/src/mal/Types.cpp
+++ b/src/mal/Types.cpp
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: MPL-2.0 */
+/* Copyright © 2019 Fragcolor Pte. Ltd. */
+/* Copyright (C) 2015 Joel Martin <github@martintribe.org> */
+
 #include "Types.h"
 #include "Debug.h"
 #include "Environment.h"

--- a/src/mal/Types.h
+++ b/src/mal/Types.h
@@ -1,3 +1,6 @@
+/* SPDX-License-Identifier: MPL-2.0 */
+/* Copyright © 2019 Fragcolor Pte. Ltd. */
+/* Copyright (C) 2015 Joel Martin <github@martintribe.org> */
 
 #ifndef INCLUDE_TYPES_H
 #define INCLUDE_TYPES_H

--- a/src/mal/Validation.cpp
+++ b/src/mal/Validation.cpp
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: MPL-2.0 */
+/* Copyright © 2020 Fragcolor Pte. Ltd. */
+/* Copyright (C) 2015 Joel Martin <github@martintribe.org> */
+
 #include "Types.h"
 
 int checkArgsIs(const char *name, int expected, int got, malValuePtr val) {

--- a/src/mal/stepA_mal.cpp
+++ b/src/mal/stepA_mal.cpp
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: MPL-2.0 */
+/* Copyright © 2019 Fragcolor Pte. Ltd. */
+/* Copyright (C) 2015 Joel Martin <github@martintribe.org> */
+
 #include "MAL.h"
 
 #include "Environment.h"

--- a/src/tests/PyBlock1.py
+++ b/src/tests/PyBlock1.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright © 2020 Fragcolor Pte. Ltd.
+
 import sys
 
 ## This could also work!!

--- a/src/tests/PyBlock2.py
+++ b/src/tests/PyBlock2.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright © 2020 Fragcolor Pte. Ltd.
+
 import asyncio
 import sys
 

--- a/src/tests/audio.edn
+++ b/src/tests/audio.edn
@@ -1,3 +1,6 @@
+; SPDX-License-Identifier: BSD-3-Clause
+; Copyright © 2021 Fragcolor Pte. Ltd.
+
 (defnode main)
 
 (defloop play-files

--- a/src/tests/bgfx.clj
+++ b/src/tests/bgfx.clj
@@ -1,3 +1,6 @@
+; SPDX-License-Identifier: BSD-3-Clause
+; Copyright © 2019 Fragcolor Pte. Ltd.
+
 (def! Root (Node))
 
 (def cube

--- a/src/tests/bgfx_small.clj
+++ b/src/tests/bgfx_small.clj
@@ -1,3 +1,6 @@
+; SPDX-License-Identifier: BSD-3-Clause
+; Copyright © 2019 Fragcolor Pte. Ltd.
+
 (do
   (def action
     (Chain

--- a/src/tests/bigint.clj
+++ b/src/tests/bigint.clj
@@ -1,3 +1,6 @@
+; SPDX-License-Identifier: BSD-3-Clause
+; Copyright © 2020 Fragcolor Pte. Ltd.
+
 (def Root (Node))
 
 (def test

--- a/src/tests/blocks.clj
+++ b/src/tests/blocks.clj
@@ -1,3 +1,6 @@
+; SPDX-License-Identifier: BSD-3-Clause
+; Copyright © 2021 Fragcolor Pte. Ltd.
+
 ;; (prn (blocks))
 (prn (map (fn* [name] [name (info name)]) (blocks)))
 (prn (export-strings))

--- a/src/tests/branch.edn
+++ b/src/tests/branch.edn
@@ -1,3 +1,6 @@
+; SPDX-License-Identifier: BSD-3-Clause
+; Copyright © 2021 Fragcolor Pte. Ltd.
+
 (defnode main)
 
 (defloop c1

--- a/src/tests/brotli.clj
+++ b/src/tests/brotli.clj
@@ -1,3 +1,6 @@
+; SPDX-License-Identifier: BSD-3-Clause
+; Copyright © 2020 Fragcolor Pte. Ltd.
+
 (def Root (Node))
 
 (schedule

--- a/src/tests/cbperf.clj
+++ b/src/tests/cbperf.clj
@@ -1,3 +1,6 @@
+; SPDX-License-Identifier: BSD-3-Clause
+; Copyright © 2019 Fragcolor Pte. Ltd.
+
 ; valgrind --tool=callgrind --dump-instr=yes --collect-jumps=yes ./cblp ../../chainblocks/src/tests/cbperf.clj
 (def Root (Node))
 (schedule Root (Chain "analysis" ; :Looped

--- a/src/tests/chain-macro.edn
+++ b/src/tests/chain-macro.edn
@@ -1,3 +1,6 @@
+; SPDX-License-Identifier: BSD-3-Clause
+; Copyright © 2021 Fragcolor Pte. Ltd.
+
 (defmacro! defchain (fn* [name & blocks] `(def! ~(symbol (str name)) (Chain ~(str name) (chainify (vector ~@blocks))))))
 (defmacro! defloop (fn* [name & blocks] `(def! ~(symbol (str name)) (Chain ~(str name) :Looped (chainify (vector ~@blocks))))))
 (defmacro! defblocks (fn* [name args & blocks] `(defn ~(symbol (str name)) ~args (chainify (vector ~@blocks)))))

--- a/src/tests/chains_embed_issue.edn
+++ b/src/tests/chains_embed_issue.edn
@@ -1,3 +1,6 @@
+; SPDX-License-Identifier: BSD-3-Clause
+; Copyright © 2021 Fragcolor Pte. Ltd.
+
 (defn logic [blocks]
   (-> (Maybe blocks)))
 

--- a/src/tests/channels.clj
+++ b/src/tests/channels.clj
@@ -1,3 +1,6 @@
+; SPDX-License-Identifier: BSD-3-Clause
+; Copyright © 2020 Fragcolor Pte. Ltd.
+
 (def Root (Node))
 
 (def producer

--- a/src/tests/const-vars.edn
+++ b/src/tests/const-vars.edn
@@ -1,3 +1,6 @@
+; SPDX-License-Identifier: BSD-3-Clause
+; Copyright © 2021 Fragcolor Pte. Ltd.
+
 (defnode Main)
 (defloop test
   10 = .10

--- a/src/tests/continuations.clj
+++ b/src/tests/continuations.clj
@@ -1,3 +1,6 @@
+; SPDX-License-Identifier: BSD-3-Clause
+; Copyright © 2020 Fragcolor Pte. Ltd.
+
 (def Root (Node))
 
 (def depth1Chain

--- a/src/tests/crash.clj
+++ b/src/tests/crash.clj
@@ -1,2 +1,5 @@
+; SPDX-License-Identifier: BSD-3-Clause
+; Copyright © 2019 Fragcolor Pte. Ltd.
+
 (def! root (Node))
 (schedule root (Chain "crash" 10 (Assert.Is 1 true)))

--- a/src/tests/demo.clj
+++ b/src/tests/demo.clj
@@ -1,3 +1,6 @@
+; SPDX-License-Identifier: BSD-3-Clause
+; Copyright © 2019 Fragcolor Pte. Ltd.
+
 ;; Sample 1
 
 (schedule

--- a/src/tests/edn.edn
+++ b/src/tests/edn.edn
@@ -1,3 +1,6 @@
+; SPDX-License-Identifier: BSD-3-Clause
+; Copyright © 2021 Fragcolor Pte. Ltd.
+
 (defnode main)
 
 (defchain uglify

--- a/src/tests/eth.edn
+++ b/src/tests/eth.edn
@@ -1,3 +1,6 @@
+; SPDX-License-Identifier: BSD-3-Clause
+; Copyright © 2021 Fragcolor Pte. Ltd.
+
 (defnode Main)
 
 (def abi "

--- a/src/tests/failures.clj
+++ b/src/tests/failures.clj
@@ -1,3 +1,6 @@
+; SPDX-License-Identifier: BSD-3-Clause
+; Copyright © 2020 Fragcolor Pte. Ltd.
+
 (def Root (Node))
 
 ; fail during await, uses awaitne(...)

--- a/src/tests/fib.clj
+++ b/src/tests/fib.clj
@@ -1,3 +1,6 @@
+; SPDX-License-Identifier: BSD-3-Clause
+; Copyright © 2020 Fragcolor Pte. Ltd.
+
 ;; Not the best subject for chainblocks at all
 ;; but still if competitive in this would be nice
 

--- a/src/tests/fib.py
+++ b/src/tests/fib.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright © 2020 Fragcolor Pte. Ltd.
+
 def fib(n):
   if n < 2: return n
   return fib(n - 1) + fib(n - 2)

--- a/src/tests/flows.clj
+++ b/src/tests/flows.clj
@@ -1,3 +1,6 @@
+; SPDX-License-Identifier: BSD-3-Clause
+; Copyright © 2019 Fragcolor Pte. Ltd.
+
 (def Root (Node))
 
 ;; Notice, if running with valgrind:

--- a/src/tests/general.edn
+++ b/src/tests/general.edn
@@ -1,3 +1,6 @@
+; SPDX-License-Identifier: BSD-3-Clause
+; Copyright © 2021 Fragcolor Pte. Ltd.
+
 (def! Root (Node))
 
 (def! inner1 (Chain "inner"

--- a/src/tests/genetic.clj
+++ b/src/tests/genetic.clj
@@ -1,3 +1,6 @@
+; SPDX-License-Identifier: BSD-3-Clause
+; Copyright © 2020 Fragcolor Pte. Ltd.
+
 (def Root (Node))
 
 (def fitness

--- a/src/tests/http.clj
+++ b/src/tests/http.clj
@@ -1,3 +1,6 @@
+; SPDX-License-Identifier: BSD-3-Clause
+; Copyright © 2020 Fragcolor Pte. Ltd.
+
 (def Root (Node))
 
 (def test

--- a/src/tests/idle.clj
+++ b/src/tests/idle.clj
@@ -1,3 +1,6 @@
+; SPDX-License-Identifier: BSD-3-Clause
+; Copyright © 2020 Fragcolor Pte. Ltd.
+
 (def Root (Node))
 
 (def detect

--- a/src/tests/imaging.clj
+++ b/src/tests/imaging.clj
@@ -1,3 +1,6 @@
+; SPDX-License-Identifier: BSD-3-Clause
+; Copyright © 2020 Fragcolor Pte. Ltd.
+
 (def Root (Node))
 
 (schedule

--- a/src/tests/infos.clj
+++ b/src/tests/infos.clj
@@ -1,3 +1,6 @@
+; SPDX-License-Identifier: BSD-3-Clause
+; Copyright © 2021 Fragcolor Pte. Ltd.
+
 ; strings are compressed by default, need to unpack if we use info
 (decompress-strings)
 (prn (map (fn* [name] [name (info name)]) (blocks)))

--- a/src/tests/infos_docs.edn
+++ b/src/tests/infos_docs.edn
@@ -1,3 +1,6 @@
+; SPDX-License-Identifier: BSD-3-Clause
+; Copyright © 2021 Fragcolor Pte. Ltd.
+
 ; run with ./build/cbl.exe ./src/tests/infos_docs.edn
 (defnode main)
 (defn dump

--- a/src/tests/kdtree.clj
+++ b/src/tests/kdtree.clj
@@ -1,3 +1,6 @@
+; SPDX-License-Identifier: BSD-3-Clause
+; Copyright © 2020 Fragcolor Pte. Ltd.
+
 ;; not meant to be something to use in production
 ;; a (Algo.KDTree) can be implemented in the future for that
 ;; this is just a proof of concept and a test for the language efficiency

--- a/src/tests/linalg.clj
+++ b/src/tests/linalg.clj
@@ -1,3 +1,6 @@
+; SPDX-License-Identifier: BSD-3-Clause
+; Copyright © 2019 Fragcolor Pte. Ltd.
+
 (def identity [(Float4 1 0 0 0)
                (Float4 0 1 0 0)
                (Float4 0 0 1 0)

--- a/src/tests/loader.clj
+++ b/src/tests/loader.clj
@@ -1,3 +1,6 @@
+; SPDX-License-Identifier: BSD-3-Clause
+; Copyright © 2019 Fragcolor Pte. Ltd.
+
 (def myChain
   (Chain
    "myChain"

--- a/src/tests/loadme-extra.clj
+++ b/src/tests/loadme-extra.clj
@@ -1,3 +1,6 @@
+; SPDX-License-Identifier: BSD-3-Clause
+; Copyright © 2021 Fragcolor Pte. Ltd.
+
 (Msg "I'm extra")
 (Msg "I'm extra again")
 defined-text1 (Log)

--- a/src/tests/loadme.clj
+++ b/src/tests/loadme.clj
@@ -1,3 +1,6 @@
+; SPDX-License-Identifier: BSD-3-Clause
+; Copyright © 2019 Fragcolor Pte. Ltd.
+
 (def defined-text1 "Hello world!")
 (Get "var")
 (Math.Add 1)

--- a/src/tests/mal.clj
+++ b/src/tests/mal.clj
@@ -1,3 +1,6 @@
+; SPDX-License-Identifier: BSD-3-Clause
+; Copyright © 2019 Fragcolor Pte. Ltd.
+
 (def chain (Chain "test" true))
 (def block1 (Do chain))
 (prn "Expect test chain deleted under")

--- a/src/tests/network.clj
+++ b/src/tests/network.clj
@@ -1,3 +1,6 @@
+; SPDX-License-Identifier: BSD-3-Clause
+; Copyright © 2019 Fragcolor Pte. Ltd.
+
 (def remote "Network.RemoteEndpoint")
 
 (def network-test-server

--- a/src/tests/pyperf.py
+++ b/src/tests/pyperf.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright © 2019 Fragcolor Pte. Ltd.
+
 import cProfile
 
 def process_one():

--- a/src/tests/pytest.clj
+++ b/src/tests/pytest.clj
@@ -1,3 +1,6 @@
+; SPDX-License-Identifier: BSD-3-Clause
+; Copyright © 2020 Fragcolor Pte. Ltd.
+
 (def Root (Node))
 (schedule Root (Chain
                 "py1"

--- a/src/tests/rust.clj
+++ b/src/tests/rust.clj
@@ -1,3 +1,6 @@
+; SPDX-License-Identifier: BSD-3-Clause
+; Copyright © 2021 Fragcolor Pte. Ltd.
+
 (def Root (Node))
 
 (schedule

--- a/src/tests/shaders.clj
+++ b/src/tests/shaders.clj
@@ -1,3 +1,6 @@
+; SPDX-License-Identifier: BSD-3-Clause
+; Copyright © 2020 Fragcolor Pte. Ltd.
+
 ; example showing how to use a wasm tool to compile a shader and load it
 
 (def Root (Node))

--- a/src/tests/shell.clj
+++ b/src/tests/shell.clj
@@ -1,3 +1,6 @@
+; SPDX-License-Identifier: BSD-3-Clause
+; Copyright © 2020 Fragcolor Pte. Ltd.
+
 (def! n (Node))
 
 (schedule

--- a/src/tests/snappy.clj
+++ b/src/tests/snappy.clj
@@ -1,3 +1,6 @@
+; SPDX-License-Identifier: BSD-3-Clause
+; Copyright © 2019 Fragcolor Pte. Ltd.
+
 (def Root (Node))
 
 (schedule

--- a/src/tests/struct.clj
+++ b/src/tests/struct.clj
@@ -1,3 +1,6 @@
+; SPDX-License-Identifier: BSD-3-Clause
+; Copyright © 2019 Fragcolor Pte. Ltd.
+
 (def Root (Node))
 
 (schedule

--- a/src/tests/subchains.clj
+++ b/src/tests/subchains.clj
@@ -1,3 +1,6 @@
+; SPDX-License-Identifier: BSD-3-Clause
+; Copyright © 2019 Fragcolor Pte. Ltd.
+
 (def root (Node))
 
 (def mychain

--- a/src/tests/tablecase.clj
+++ b/src/tests/tablecase.clj
@@ -1,3 +1,6 @@
+; SPDX-License-Identifier: BSD-3-Clause
+; Copyright © 2019 Fragcolor Pte. Ltd.
+
 ;; TODO FIXME this is failing but I think that should be OK
 ;; We store tab1 as just table var but we know nothing of the keys probably
 

--- a/src/tests/tablecase2.edn
+++ b/src/tests/tablecase2.edn
@@ -1,3 +1,6 @@
+; SPDX-License-Identifier: BSD-3-Clause
+; Copyright © 2021 Fragcolor Pte. Ltd.
+
 (defnode main)
 
 (defchain table-test-1

--- a/src/tests/test_cbl.js
+++ b/src/tests/test_cbl.js
@@ -1,3 +1,6 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+/* Copyright © 2021 Fragcolor Pte. Ltd. */
+
 const cbl = require('../../build/' + process.argv[2]);
 cbl({
   arguments: ["-e", '(do (def Root (Node)) (schedule Root (Chain "x" (Pause 2.0) (Msg "Hello") "process.kill(process.pid, \\\"SIGTERM\\\")" (_Emscripten.Eval))) (run Root 0.1))']

--- a/src/tests/test_extra.cpp
+++ b/src/tests/test_extra.cpp
@@ -1,3 +1,6 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+/* Copyright © 2020 Fragcolor Pte. Ltd. */
+
 #include <random>
 
 #include "../../include/ops.hpp"

--- a/src/tests/test_runtime.cpp
+++ b/src/tests/test_runtime.cpp
@@ -1,3 +1,6 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+/* Copyright © 2020 Fragcolor Pte. Ltd. */
+
 #include <random>
 
 #include "../../include/ops.hpp"

--- a/src/tests/test_runtime.js
+++ b/src/tests/test_runtime.js
@@ -1,3 +1,6 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+/* Copyright © 2021 Fragcolor Pte. Ltd. */
+
 const test = require('../../build/test_runtime.js');
 test({
   postRun: () => {

--- a/src/tests/time.edn
+++ b/src/tests/time.edn
@@ -1,3 +1,6 @@
+; SPDX-License-Identifier: BSD-3-Clause
+; Copyright © 2021 Fragcolor Pte. Ltd.
+
 (defnode main)
 (defchain producer
   (Sequence .sink :Types [Type.Any Type.Int] :Global true)

--- a/src/tests/variables.clj
+++ b/src/tests/variables.clj
@@ -1,3 +1,6 @@
+; SPDX-License-Identifier: BSD-3-Clause
+; Copyright © 2019 Fragcolor Pte. Ltd.
+
 (def! node (Node))
 
 (schedule

--- a/src/tests/wasm.clj
+++ b/src/tests/wasm.clj
@@ -1,3 +1,6 @@
+; SPDX-License-Identifier: BSD-3-Clause
+; Copyright © 2020 Fragcolor Pte. Ltd.
+
 (def Root (Node))
 
 (def test

--- a/src/tests/ws.clj
+++ b/src/tests/ws.clj
@@ -1,3 +1,6 @@
+; SPDX-License-Identifier: BSD-3-Clause
+; Copyright © 2020 Fragcolor Pte. Ltd.
+
 (def Root (Node))
 
 (def test


### PR DESCRIPTION
Added or updated  copyright notices in all source files (`.clj`, `.cpp`, `.edn`, `.h`, `.hpp`, `.js`, `.py`), as well as docker files.

Fixed SPDX identifier: `BSD-3-Clause` instead of the full name (see https://spdx.org/licenses/).

Note that mal source files are under the MPL-2.0 license instead. And `CBCore.cpp` is under both.

To simplify, copyright notices only include the first year of publication. There is no need to update the year, even if the file is modified in the future. Similar recommendations can be found at https://opensource.google/docs/copyright/.

```
/* SPDX-License-Identifier: BSD-3-Clause */
/* Copyright © 2019 Fragcolor Pte. Ltd. */
```