### PR TITLE
Set display in bgfx platform data

### DIFF
--- a/src/extra/bgfx.cpp
+++ b/src/extra/bgfx.cpp
@@ -338,6 +338,8 @@ struct DpiAwareness {
 struct BaseWindow : public Base {
 #ifdef _WIN32
   static inline DpiAwareness DpiAware{};
+#elif defined(__APPLE__)
+  SDL_MetalView _metalView{nullptr};
 #endif
 
   void* _sysWnd = nullptr;

--- a/src/extra/bgfx.cpp
+++ b/src/extra/bgfx.cpp
@@ -768,7 +768,7 @@ struct MainWindow : public BaseWindow {
     // set platform data this way.. or we will have issues if we re-init bgfx
     bgfx::PlatformData pdata{};
     pdata.nwh = _sysWnd;
-    // pdata.ndt = SDL_GetNativeDisplayPtr(_window);
+    pdata.ndt = SDL_GetNativeDisplayPtr(_window);
     bgfx::setPlatformData(pdata);
 
     initInfo.resolution.width = _rwidth;


### PR DESCRIPTION
Fixes a crash when creating a BGFX window on linux.
It's calling XGetXCBConnection(nullptr) if the display is not set in the platform data

Simplified SDL_GetNativeWindowPtr definition a bit to remove the specific types, since they're not used anyways