### PR TITLE
clang-format: increase ColumnLimit to 120 characters

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,6 @@
+---
+Language:        Cpp
+BasedOnStyle:    LLVM
+ColumnLimit:     120
+...
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -376,7 +376,7 @@ foreach(_file ${MY_PROJECT_SOURCE_FILES})
   if(CLANG_FORMAT_EXE)
     add_custom_command(
       OUTPUT ${_file}.formatted
-      COMMAND ${CLANG_FORMAT_EXE} -i -style=LLVM ${_file}
+      COMMAND ${CLANG_FORMAT_EXE} -i -style=file ${_file}
       )
     list(APPEND formatfied ${_file}.formatted)
   endif()


### PR DESCRIPTION
Currently blocked by #90.

Will need to add another commit after formatting all files.