### PR TITLE
Various fixes guus

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -51,7 +51,8 @@
 	url = https://github.com/chainblocks/libbacktrace.git
 [submodule "deps/wasm3"]
 	path = deps/wasm3
-	url = https://github.com/sinkingsugar/wasm3.git
+	url = https://github.com/chainblocks/wasm3.git
+	branch = main
 [submodule "deps/xxHash"]
 	path = deps/xxHash
 	url = https://github.com/chainblocks/xxHash.git

--- a/src/core/blocks/chains.cpp
+++ b/src/core/blocks/chains.cpp
@@ -68,7 +68,7 @@ struct ChainBase {
       if (chainref->valueType == CBType::Chain) {
         chain = CBChain::sharedFromRef(chainref->payload.chainValue);
       } else if (chainref->valueType == String) {
-        chain = Globals::GlobalChains[chainref->payload.stringValue];
+        chain = GetGlobals().GlobalChains[chainref->payload.stringValue];
       } else {
         chain = nullptr;
         CBLOG_DEBUG("ChainBase::compose on a null chain");
@@ -315,7 +315,7 @@ struct Wait : public ChainBase {
       if (vchain.valueType == CBType::Chain) {
         chain = CBChain::sharedFromRef(vchain.payload.chainValue);
       } else if (vchain.valueType == String) {
-        chain = Globals::GlobalChains[vchain.payload.stringValue];
+        chain = GetGlobals().GlobalChains[vchain.payload.stringValue];
       } else {
         chain = nullptr;
       }
@@ -425,7 +425,7 @@ struct StopChain : public ChainBase {
       if (vchain.valueType == CBType::Chain) {
         chain = CBChain::sharedFromRef(vchain.payload.chainValue);
       } else if (vchain.valueType == String) {
-        chain = Globals::GlobalChains[vchain.payload.stringValue];
+        chain = GetGlobals().GlobalChains[vchain.payload.stringValue];
       } else {
         chain = nullptr;
       }
@@ -966,7 +966,7 @@ struct ChainLoader : public BaseLoader<ChainLoader> {
       data.shared = _sharedCopy;
       data.chain = context->chainStack.back();
       assert(data.chain->node.lock());
-      _provider->setup(_provider, Globals::RootPath.c_str(), data);
+      _provider->setup(_provider, GetGlobals().RootPath.c_str(), data);
     }
 
     if (unlikely(_provider->updated(_provider))) {

--- a/src/core/blocks/core.hpp
+++ b/src/core/blocks/core.hpp
@@ -726,7 +726,7 @@ struct SetBase : public VariableBase {
 
         // Not initialized yet
         _target->valueType = Table;
-        _target->payload.tableValue.api = &Globals::TableInterface;
+        _target->payload.tableValue.api = &GetGlobals().TableInterface;
         _target->payload.tableValue.opaque = new CBMap();
       }
 
@@ -876,7 +876,7 @@ struct Ref : public SetBase {
       if (_target->valueType != Table) {
         // Not initialized yet
         _target->valueType = Table;
-        _target->payload.tableValue.api = &Globals::TableInterface;
+        _target->payload.tableValue.api = &GetGlobals().TableInterface;
         _target->payload.tableValue.opaque = new CBMap();
       }
 
@@ -1327,7 +1327,7 @@ struct SeqBase : public VariableBase {
       if (_target->valueType != Table) {
         // Not initialized yet
         _target->valueType = Table;
-        _target->payload.tableValue.api = &Globals::TableInterface;
+        _target->payload.tableValue.api = &GetGlobals().TableInterface;
         _target->payload.tableValue.opaque = new CBMap();
       }
 
@@ -1739,7 +1739,7 @@ struct TableDecl : public VariableBase {
       if (_target->valueType != Table) {
         // Not initialized yet
         _target->valueType = Table;
-        _target->payload.tableValue.api = &Globals::TableInterface;
+        _target->payload.tableValue.api = &GetGlobals().TableInterface;
         _target->payload.tableValue.opaque = new CBMap();
       }
 
@@ -1752,7 +1752,7 @@ struct TableDecl : public VariableBase {
         if (table->valueType != Table) {
           // Not initialized yet
           table->valueType = Table;
-          table->payload.tableValue.api = &Globals::TableInterface;
+          table->payload.tableValue.api = &GetGlobals().TableInterface;
           table->payload.tableValue.opaque = new CBMap();
         }
       } else {
@@ -1761,7 +1761,7 @@ struct TableDecl : public VariableBase {
     } else {
       if (_target->valueType != Table) {
         _target->valueType = Table;
-        _target->payload.tableValue.api = &Globals::TableInterface;
+        _target->payload.tableValue.api = &GetGlobals().TableInterface;
         _target->payload.tableValue.opaque = new CBMap();
       }
       _cell = _target;
@@ -1779,7 +1779,7 @@ struct TableDecl : public VariableBase {
     if (table->valueType != Table) {
       // Not initialized yet
       table->valueType = Table;
-      table->payload.tableValue.api = &Globals::TableInterface;
+      table->payload.tableValue.api = &GetGlobals().TableInterface;
       table->payload.tableValue.opaque = new CBMap();
     }
   }
@@ -2020,7 +2020,7 @@ struct SeqUser : VariableBase {
         // We need to init this in order to fetch cell addr
         // Not initialized yet
         _target->valueType = Table;
-        _target->payload.tableValue.api = &Globals::TableInterface;
+        _target->payload.tableValue.api = &GetGlobals().TableInterface;
         _target->payload.tableValue.opaque = new CBMap();
       }
 

--- a/src/core/blocks/edn.cpp
+++ b/src/core/blocks/edn.cpp
@@ -188,7 +188,7 @@ struct Uglify {
       CBMap m = to_var(std::get<form::FormWrapperMap>(form));
       CBVar tmp{};
       tmp.valueType = CBType::Table;
-      tmp.payload.tableValue.api = &Globals::TableInterface;
+      tmp.payload.tableValue.api = &GetGlobals().TableInterface;
       tmp.payload.tableValue.opaque = &m;
       return tmp;
     }
@@ -384,7 +384,7 @@ struct Parse {
       CBMap m = to_var(std::get<form::FormWrapperMap>(form));
       CBVar tmp{};
       tmp.valueType = CBType::Table;
-      tmp.payload.tableValue.api = &Globals::TableInterface;
+      tmp.payload.tableValue.api = &GetGlobals().TableInterface;
       tmp.payload.tableValue.opaque = &m;
       return tmp;
     }

--- a/src/core/blocks/http.cpp
+++ b/src/core/blocks/http.cpp
@@ -130,7 +130,7 @@ struct Base {
         CBVar empty{};
         empty.valueType = CBType::Table;
         empty.payload.tableValue.opaque = &m;
-        empty.payload.tableValue.api = &Globals::TableInterface;
+        empty.payload.tableValue.api = &GetGlobals().TableInterface;
         outMap["headers"] = empty;
       }
       break;
@@ -274,7 +274,7 @@ template <const string_view &METHOD> struct GetLike : public Base {
         CBVar res{};
         res.valueType = CBType::Table;
         res.payload.tableValue.opaque = &outMap;
-        res.payload.tableValue.api = &Globals::TableInterface;
+        res.payload.tableValue.api = &GetGlobals().TableInterface;
         return res;
       } else {
         if (asBytes) {
@@ -381,7 +381,7 @@ template <const string_view &METHOD> struct PostLike : public Base {
         CBVar res{};
         res.valueType = CBType::Table;
         res.payload.tableValue.opaque = &outMap;
-        res.payload.tableValue.api = &Globals::TableInterface;
+        res.payload.tableValue.api = &GetGlobals().TableInterface;
         return res;
       } else {
         if (asBytes) {
@@ -634,7 +634,7 @@ struct Read {
     auto res = CBVar();
     res.valueType = Table;
     res.payload.tableValue.opaque = &_output;
-    res.payload.tableValue.api = &Globals::TableInterface;
+    res.payload.tableValue.api = &GetGlobals().TableInterface;
     return res;
   }
 
@@ -805,7 +805,7 @@ struct SendFile {
   CBVar activate(CBContext *context, const CBVar &input) {
     auto peer = reinterpret_cast<Peer *>(_peerVar->payload.objectValue);
 
-    std::filesystem::path p{Globals::RootPath};
+    std::filesystem::path p{GetGlobals().RootPath};
     p += input.payload.stringValue;
 
     http::file_body::value_type file;

--- a/src/core/blocks/json.cpp
+++ b/src/core/blocks/json.cpp
@@ -497,7 +497,7 @@ void from_json(const json &j, CBVar &var) {
   case CBType::Table: {
     auto map = new chainblocks::CBMap();
     var.valueType = CBType::Table;
-    var.payload.tableValue.api = &chainblocks::Globals::TableInterface;
+    var.payload.tableValue.api = &chainblocks::GetGlobals().TableInterface;
     var.payload.tableValue.opaque = map;
     auto items = j.at("values").get<std::vector<json>>();
     for (const auto &item : items) {
@@ -510,7 +510,7 @@ void from_json(const json &j, CBVar &var) {
   case CBType::Set: {
     auto set = new chainblocks::CBHashSet();
     var.valueType = CBType::Set;
-    var.payload.setValue.api = &chainblocks::Globals::SetInterface;
+    var.payload.setValue.api = &chainblocks::GetGlobals().SetInterface;
     var.payload.setValue.opaque = set;
     auto items = j.at("values").get<std::vector<json>>();
     for (const auto &item : items) {
@@ -569,8 +569,8 @@ void from_json(const json &j, CBVar &var) {
     var.payload.objectValue = nullptr;
     int64_t id =
         (int64_t)var.payload.objectVendorId << 32 | var.payload.objectTypeId;
-    auto it = chainblocks::Globals::ObjectTypesRegister.find(id);
-    if (it != chainblocks::Globals::ObjectTypesRegister.end()) {
+    auto it = chainblocks::GetGlobals().ObjectTypesRegister.find(id);
+    if (it != chainblocks::GetGlobals().ObjectTypesRegister.end()) {
       auto &info = it->second;
       auto data = j.at("data").get<std::vector<uint8_t>>();
       var.payload.objectValue = info.deserialize(&data.front(), data.size());
@@ -773,7 +773,7 @@ struct FromJson {
     } else if (j.is_object()) {
       storage.valueType = Table;
       auto map = new chainblocks::CBMap();
-      storage.payload.tableValue.api = &chainblocks::Globals::TableInterface;
+      storage.payload.tableValue.api = &chainblocks::GetGlobals().TableInterface;
       storage.payload.tableValue.opaque = map;
       for (auto &[key, value] : j.items()) {
         anyParse(value, (*map)[key]);

--- a/src/core/blocks/wasm.cpp
+++ b/src/core/blocks/wasm.cpp
@@ -464,7 +464,7 @@ m3ApiRawFunction(m3_wasi_unstable_path_filestat_get) {
   CBLOG_TRACE("WASI m3_wasi_unstable_path_filestat_get, path: {}", path);
 
   std::filesystem::path fp{path};
-  std::filesystem::path rp{chainblocks::Globals::RootPath};
+  std::filesystem::path rp{chainblocks::GetGlobals().RootPath};
   std::filesystem::path p = rp / fp;
   auto ps = p.string();
 

--- a/src/core/edn/print.hpp
+++ b/src/core/edn/print.hpp
@@ -16,7 +16,7 @@
 namespace chainblocks {
 namespace edn {
 
-std::string to_string(double d) {
+inline std::string to_string(double d) {
   std::ostringstream stm;
   stm << d;
   if (d == int64_t(d)) {

--- a/src/core/edn/read.hpp
+++ b/src/core/edn/read.hpp
@@ -15,6 +15,7 @@
 #include <unordered_map>
 #include <variant>
 #include <vector>
+#include <optional>
 
 namespace chainblocks {
 namespace edn {

--- a/src/core/foundation.hpp
+++ b/src/core/foundation.hpp
@@ -434,36 +434,36 @@ struct RestartChainException : public CBException {
 };
 
 struct Globals {
-  static inline std::mutex SettingsMutex;
-  static inline std::unordered_map<std::string, OwnedVar> Settings;
+  std::mutex SettingsMutex;
+  std::unordered_map<std::string, OwnedVar> Settings;
 
-  static inline int SigIntTerm{0};
-  static inline std::unordered_map<std::string_view, CBBlockConstructor>
+  int SigIntTerm{0};
+  std::unordered_map<std::string_view, CBBlockConstructor>
       BlocksRegister;
-  static inline std::unordered_map<std::string_view, std::string_view>
+  std::unordered_map<std::string_view, std::string_view>
       BlockNamesToFullTypeNames;
-  static inline std::unordered_map<int64_t, CBObjectInfo> ObjectTypesRegister;
-  static inline std::unordered_map<int64_t, CBEnumInfo> EnumTypesRegister;
+  std::unordered_map<int64_t, CBObjectInfo> ObjectTypesRegister;
+  std::unordered_map<int64_t, CBEnumInfo> EnumTypesRegister;
 
   // map = ordered! we need that for those
-  static inline std::map<std::string_view, CBCallback> RunLoopHooks;
-  static inline std::map<std::string_view, CBCallback> ExitHooks;
+  std::map<std::string_view, CBCallback> RunLoopHooks;
+  std::map<std::string_view, CBCallback> ExitHooks;
 
-  static inline std::unordered_map<std::string, std::shared_ptr<CBChain>>
+  std::unordered_map<std::string, std::shared_ptr<CBChain>>
       GlobalChains;
 
-  static inline std::list<std::weak_ptr<RuntimeObserver>> Observers;
+  std::list<std::weak_ptr<RuntimeObserver>> Observers;
 
-  static inline std::string RootPath;
-  static inline std::string ExePath;
+  std::string RootPath;
+  std::string ExePath;
 
-  static inline std::exception_ptr StopChainEx;
-  static inline std::exception_ptr RestartChainEx;
+  std::exception_ptr StopChainEx;
+  std::exception_ptr RestartChainEx;
 
-  static inline std::unordered_map<uint32_t, CBOptionalString>
+  std::unordered_map<uint32_t, CBOptionalString>
       *CompressedStrings{nullptr};
 
-  static inline CBTableInterface TableInterface{
+  CBTableInterface TableInterface{
       .tableGetIterator =
           [](CBTable table, CBTableIterator *outIter) {
             if (outIter == nullptr)
@@ -530,7 +530,7 @@ struct Globals {
             delete map;
           }};
 
-  static inline CBSetInterface SetInterface{
+  CBSetInterface SetInterface{
       .setGetIterator =
           [](CBSet cbset, CBSetIterator *outIter) {
             if (outIter == nullptr)
@@ -595,6 +595,8 @@ struct Globals {
             delete set;
           }};
 };
+
+Globals& GetGlobals();
 
 template <typename T>
 NO_INLINE void arrayGrow(T &arr, size_t addlen, size_t min_cap = 4);
@@ -919,14 +921,14 @@ struct InternalCore {
   // need to emulate dllblock Core a bit
   static CBTable tableNew() {
     CBTable res;
-    res.api = &chainblocks::Globals::TableInterface;
+    res.api = &chainblocks::GetGlobals().TableInterface;
     res.opaque = new chainblocks::CBMap();
     return res;
   }
 
   static CBSet setNew() {
     CBSet res;
-    res.api = &chainblocks::Globals::SetInterface;
+    res.api = &chainblocks::GetGlobals().SetInterface;
     res.opaque = new chainblocks::CBHashSet();
     return res;
   }

--- a/src/core/ops_internal.cpp
+++ b/src/core/ops_internal.cpp
@@ -7,47 +7,47 @@
 
 std::ostream &operator<<(std::ostream &os, const CBVar &var) {
   switch (var.valueType) {
-  case EndOfBlittableTypes:
+  case CBType::EndOfBlittableTypes:
     break;
-  case None:
+  case CBType::None:
     os << "None";
     break;
   case CBType::Any:
     os << "Any";
     break;
-  case Object:
+  case CBType::Object:
     os << "Object: 0x" << std::hex
        << reinterpret_cast<uintptr_t>(var.payload.objectValue) << " vendor: 0x"
        << var.payload.objectVendorId << " type: 0x" << var.payload.objectTypeId
        << std::dec;
     break;
-  case Chain:
+  case CBType::Chain:
     os << "Chain: 0x" << std::hex
        << reinterpret_cast<uintptr_t>(var.payload.chainValue) << std::dec;
     break;
-  case Bytes:
+  case CBType::Bytes:
     os << "Bytes: 0x" << std::hex
        << reinterpret_cast<uintptr_t>(var.payload.bytesValue)
        << " size: " << std::dec << var.payload.bytesSize;
     break;
-  case Array:
+  case CBType::Array:
     os << "Array: 0x" << std::hex
        << reinterpret_cast<uintptr_t>(var.payload.arrayValue.elements)
        << " size: " << std::dec << var.payload.arrayValue.len
        << " of: " << type2Name(var.innerType);
     break;
-  case Enum:
+  case CBType::Enum:
     os << "Enum: " << var.payload.enumValue << std::hex << " vendor: 0x"
        << var.payload.enumVendorId << " type: 0x" << var.payload.enumTypeId
        << std::dec;
     break;
-  case Bool:
+  case CBType::Bool:
     os << (var.payload.boolValue ? "true" : "false");
     break;
-  case Int:
+  case CBType::Int:
     os << var.payload.intValue;
     break;
-  case Int2:
+  case CBType::Int2:
     os << "(";
     for (auto i = 0; i < 2; i++) {
       if (i == 0)
@@ -57,7 +57,7 @@ std::ostream &operator<<(std::ostream &os, const CBVar &var) {
     }
     os << ")";
     break;
-  case Int3:
+  case CBType::Int3:
     os << "(";
     for (auto i = 0; i < 3; i++) {
       if (i == 0)
@@ -67,7 +67,7 @@ std::ostream &operator<<(std::ostream &os, const CBVar &var) {
     }
     os << ")";
     break;
-  case Int4:
+  case CBType::Int4:
     os << "(";
     for (auto i = 0; i < 4; i++) {
       if (i == 0)
@@ -77,7 +77,7 @@ std::ostream &operator<<(std::ostream &os, const CBVar &var) {
     }
     os << ")";
     break;
-  case Int8:
+  case CBType::Int8:
     os << "(";
     for (auto i = 0; i < 8; i++) {
       if (i == 0)
@@ -87,7 +87,7 @@ std::ostream &operator<<(std::ostream &os, const CBVar &var) {
     }
     os << ")";
     break;
-  case Int16:
+  case CBType::Int16:
     os << "(";
     for (auto i = 0; i < 16; i++) {
       if (i == 0)
@@ -97,10 +97,10 @@ std::ostream &operator<<(std::ostream &os, const CBVar &var) {
     }
     os << ")";
     break;
-  case Float:
+  case CBType::Float:
     os << var.payload.floatValue;
     break;
-  case Float2:
+  case CBType::Float2:
     os << "(";
     for (auto i = 0; i < 2; i++) {
       if (i == 0)
@@ -110,7 +110,7 @@ std::ostream &operator<<(std::ostream &os, const CBVar &var) {
     }
     os << ")";
     break;
-  case Float3:
+  case CBType::Float3:
     os << "(";
     for (auto i = 0; i < 3; i++) {
       if (i == 0)
@@ -120,7 +120,7 @@ std::ostream &operator<<(std::ostream &os, const CBVar &var) {
     }
     os << ")";
     break;
-  case Float4:
+  case CBType::Float4:
     os << "(";
     for (auto i = 0; i < 4; i++) {
       if (i == 0)
@@ -130,12 +130,12 @@ std::ostream &operator<<(std::ostream &os, const CBVar &var) {
     }
     os << ")";
     break;
-  case Color:
+  case CBType::Color:
     os << int(var.payload.colorValue.r) << ", " << int(var.payload.colorValue.g)
        << ", " << int(var.payload.colorValue.b) << ", "
        << int(var.payload.colorValue.a);
     break;
-  case Block:
+  case CBType::Block:
     os << "Block: " << var.payload.blockValue->name(var.payload.blockValue);
     break;
   case CBType::String:
@@ -144,25 +144,25 @@ std::ostream &operator<<(std::ostream &os, const CBVar &var) {
     else
       os << "\"" << var.payload.stringValue << "\"";
     break;
-  case ContextVar:
+  case CBType::ContextVar:
     os << "ContextVariable: " << var.payload.stringValue;
     break;
   case CBType::Path:
     os << "Path: " << var.payload.stringValue;
     break;
-  case Image:
+  case CBType::Image:
     os << "Image";
     os << " Width: " << var.payload.imageValue.width;
     os << " Height: " << var.payload.imageValue.height;
     os << " Channels: " << (int)var.payload.imageValue.channels;
     break;
-  case Audio:
+  case CBType::Audio:
     os << "Audio";
     os << " SampleRate: " << var.payload.audioValue.sampleRate;
     os << " Samples: " << var.payload.audioValue.nsamples;
     os << " Channels: " << var.payload.audioValue.channels;
     break;
-  case Seq:
+  case CBType::Seq:
     os << "[";
     for (uint32_t i = 0; i < var.payload.seqValue.len; i++) {
       const auto &v = var.payload.seqValue.elements[i];
@@ -191,7 +191,7 @@ std::ostream &operator<<(std::ostream &os, const CBVar &var) {
     }
     os << "}";
   } break;
-  case Set: {
+  case CBType::Set: {
     os << "{";
     auto &s = var.payload.setValue;
     bool first = true;
@@ -473,15 +473,15 @@ bool operator==(const CBTypeInfo &a, const CBTypeInfo &b) {
   if (a.basicType != b.basicType)
     return false;
   switch (a.basicType) {
-  case Object:
+  case CBType::Object:
     if (a.object.vendorId != b.object.vendorId)
       return false;
     return a.object.typeId == b.object.typeId;
-  case Enum:
+  case CBType::Enum:
     if (a.enumeration.vendorId != b.enumeration.vendorId)
       return false;
     return a.enumeration.typeId == b.enumeration.typeId;
-  case Seq: {
+  case CBType::Seq: {
     if (a.seqTypes.elements == nullptr && b.seqTypes.elements == nullptr)
       return true;
 
@@ -508,7 +508,7 @@ bool operator==(const CBTypeInfo &a, const CBTypeInfo &b) {
 
     return true;
   }
-  case Set: {
+  case CBType::Set: {
     if (a.setTypes.elements == nullptr && b.setTypes.elements == nullptr)
       return true;
 
@@ -535,7 +535,7 @@ bool operator==(const CBTypeInfo &a, const CBTypeInfo &b) {
 
     return true;
   }
-  case Table: {
+  case CBType::Table: {
     auto atypes = a.table.types.len;
     auto btypes = b.table.types.len;
     if (atypes != btypes)

--- a/src/core/runtime.cpp
+++ b/src/core/runtime.cpp
@@ -56,8 +56,8 @@ namespace chainblocks {
 CBOptionalString getCompiledCompressedString(uint32_t id) {
   static std::unordered_map<uint32_t, CBOptionalString>
       CompiledCompressedStrings;
-  if (Globals::CompressedStrings == nullptr)
-    Globals::CompressedStrings = &CompiledCompressedStrings;
+  if (GetGlobals().CompressedStrings == nullptr)
+    GetGlobals().CompressedStrings = &CompiledCompressedStrings;
   auto &val = CompiledCompressedStrings[id];
   val.crc = id; // make sure we return with crc to allow later lookups!
   return val;
@@ -66,8 +66,8 @@ CBOptionalString getCompiledCompressedString(uint32_t id) {
 CBOptionalString setCompiledCompressedString(uint32_t id, const char *str) {
   static std::unordered_map<uint32_t, CBOptionalString>
       CompiledCompressedStrings;
-  if (Globals::CompressedStrings == nullptr)
-    Globals::CompressedStrings = &CompiledCompressedStrings;
+  if (GetGlobals().CompressedStrings == nullptr)
+    GetGlobals().CompressedStrings = &CompiledCompressedStrings;
   CBOptionalString ls{str, id};
   CompiledCompressedStrings[id] = ls;
   return ls;
@@ -187,27 +187,27 @@ void registerCoreBlocks() {
 
   globalRegisterDone = true;
 
-  if (Globals::RootPath.size() > 0) {
+  if (GetGlobals().RootPath.size() > 0) {
     // set root path as current directory
-    std::filesystem::current_path(Globals::RootPath);
+    std::filesystem::current_path(GetGlobals().RootPath);
   } else {
     // set current path as root path
     auto cp = std::filesystem::current_path();
-    Globals::RootPath = cp.string();
+    GetGlobals().RootPath = cp.string();
   }
 
 // UTF8 on windows
 #ifdef _WIN32
   SetConsoleOutputCP(CP_UTF8);
   namespace fs = std::filesystem;
-  if (Globals::ExePath.size() > 0) {
-    auto pluginPath = fs::absolute(Globals::ExePath) / "cblocks";
+  if (GetGlobals().ExePath.size() > 0) {
+    auto pluginPath = fs::absolute(GetGlobals().ExePath) / "cblocks";
     auto pluginPathStr = pluginPath.wstring();
     CBLOG_DEBUG("Adding dll path: {}", pluginPath.string());
     AddDllDirectory(pluginPathStr.c_str());
   }
-  if (Globals::RootPath.size() > 0) {
-    auto pluginPath = fs::absolute(Globals::RootPath) / "cblocks";
+  if (GetGlobals().RootPath.size() > 0) {
+    auto pluginPath = fs::absolute(GetGlobals().RootPath) / "cblocks";
     auto pluginPathStr = pluginPath.wstring();
     CBLOG_DEBUG("Adding dll path: {}", pluginPath.string());
     AddDllDirectory(pluginPathStr.c_str());
@@ -248,13 +248,13 @@ void registerCoreBlocks() {
   try {
     throw StopChainException();
   } catch (...) {
-    Globals::StopChainEx = std::current_exception();
+    GetGlobals().StopChainEx = std::current_exception();
   }
 
   try {
     throw RestartChainException();
   } catch (...) {
-    Globals::RestartChainEx = std::current_exception();
+    GetGlobals().RestartChainEx = std::current_exception();
   }
 
   // at this point we might have some auto magical static linked block already
@@ -262,10 +262,10 @@ void registerCoreBlocks() {
   // as we assume the observers were setup in this call caller so too late for
   // them
   std::vector<std::pair<std::string_view, CBBlockConstructor>> earlyblocks;
-  for (auto &pair : Globals::BlocksRegister) {
+  for (auto &pair : GetGlobals().BlocksRegister) {
     earlyblocks.push_back(pair);
   }
-  Globals::BlocksRegister.clear();
+  GetGlobals().BlocksRegister.clear();
 
   static_assert(sizeof(CBVarPayload) == 16);
   static_assert(sizeof(CBVar) == 32);
@@ -304,10 +304,10 @@ void registerCoreBlocks() {
 #endif
 
   // Enums are auto registered we need to propagate them to observers
-  for (auto &einfo : Globals::EnumTypesRegister) {
+  for (auto &einfo : GetGlobals().EnumTypesRegister) {
     int32_t vendorId = (int32_t)((einfo.first & 0xFFFFFFFF00000000) >> 32);
     int32_t enumId = (int32_t)(einfo.first & 0x00000000FFFFFFFF);
-    for (auto &pobs : Globals::Observers) {
+    for (auto &pobs : GetGlobals().Observers) {
       if (pobs.expired())
         continue;
       auto obs = pobs.lock();
@@ -325,9 +325,9 @@ void registerCoreBlocks() {
   }
 
   // finally iterate cblock directory and load external dlls
-  loadExternalBlocks(Globals::ExePath);
-  if (Globals::RootPath != Globals::ExePath) {
-    loadExternalBlocks(Globals::RootPath);
+  loadExternalBlocks(GetGlobals().ExePath);
+  if (GetGlobals().RootPath != GetGlobals().ExePath) {
+    loadExternalBlocks(GetGlobals().RootPath);
   }
 
 #ifdef __EMSCRIPTEN__
@@ -357,8 +357,8 @@ void registerCoreBlocks() {
 }
 
 CBlock *createBlock(std::string_view name) {
-  auto it = Globals::BlocksRegister.find(name);
-  if (it == Globals::BlocksRegister.end()) {
+  auto it = GetGlobals().BlocksRegister.find(name);
+  if (it == GetGlobals().BlocksRegister.end()) {
     return nullptr;
   }
 
@@ -436,17 +436,17 @@ CBlock *createBlock(std::string_view name) {
 
 void registerBlock(std::string_view name, CBBlockConstructor constructor,
                    std::string_view fullTypeName) {
-  auto findIt = Globals::BlocksRegister.find(name);
-  if (findIt == Globals::BlocksRegister.end()) {
-    Globals::BlocksRegister.insert(std::make_pair(name, constructor));
+  auto findIt = GetGlobals().BlocksRegister.find(name);
+  if (findIt == GetGlobals().BlocksRegister.end()) {
+    GetGlobals().BlocksRegister.insert(std::make_pair(name, constructor));
   } else {
-    Globals::BlocksRegister[name] = constructor;
+    GetGlobals().BlocksRegister[name] = constructor;
     CBLOG_INFO("Overriding block: {}", name);
   }
 
-  Globals::BlockNamesToFullTypeNames[name] = fullTypeName;
+  GetGlobals().BlockNamesToFullTypeNames[name] = fullTypeName;
 
-  for (auto &pobs : Globals::Observers) {
+  for (auto &pobs : GetGlobals().Observers) {
     if (pobs.expired())
       continue;
     auto obs = pobs.lock();
@@ -457,15 +457,15 @@ void registerBlock(std::string_view name, CBBlockConstructor constructor,
 void registerObjectType(int32_t vendorId, int32_t typeId, CBObjectInfo info) {
   int64_t id = (int64_t)vendorId << 32 | typeId;
   auto typeName = std::string(info.name);
-  auto findIt = Globals::ObjectTypesRegister.find(id);
-  if (findIt == Globals::ObjectTypesRegister.end()) {
-    Globals::ObjectTypesRegister.insert(std::make_pair(id, info));
+  auto findIt = GetGlobals().ObjectTypesRegister.find(id);
+  if (findIt == GetGlobals().ObjectTypesRegister.end()) {
+    GetGlobals().ObjectTypesRegister.insert(std::make_pair(id, info));
   } else {
-    Globals::ObjectTypesRegister[id] = info;
+    GetGlobals().ObjectTypesRegister[id] = info;
     CBLOG_INFO("Overriding object type: {}", typeName);
   }
 
-  for (auto &pobs : Globals::Observers) {
+  for (auto &pobs : GetGlobals().Observers) {
     if (pobs.expired())
       continue;
     auto obs = pobs.lock();
@@ -476,15 +476,15 @@ void registerObjectType(int32_t vendorId, int32_t typeId, CBObjectInfo info) {
 void registerEnumType(int32_t vendorId, int32_t typeId, CBEnumInfo info) {
   int64_t id = (int64_t)vendorId << 32 | typeId;
   auto typeName = std::string(info.name);
-  auto findIt = Globals::EnumTypesRegister.find(id);
-  if (findIt == Globals::EnumTypesRegister.end()) {
-    Globals::EnumTypesRegister.insert(std::make_pair(id, info));
+  auto findIt = GetGlobals().EnumTypesRegister.find(id);
+  if (findIt == GetGlobals().EnumTypesRegister.end()) {
+    GetGlobals().EnumTypesRegister.insert(std::make_pair(id, info));
   } else {
-    Globals::EnumTypesRegister[id] = info;
-    CBLOG_INFO("Overriding enum type: {}", typeName);
+    GetGlobals().EnumTypesRegister[id] = info;
+    CBLOG_DEBUG("Overriding enum type: {}", typeName);
   }
 
-  for (auto &pobs : Globals::Observers) {
+  for (auto &pobs : GetGlobals().Observers) {
     if (pobs.expired())
       continue;
     auto obs = pobs.lock();
@@ -493,43 +493,43 @@ void registerEnumType(int32_t vendorId, int32_t typeId, CBEnumInfo info) {
 }
 
 void registerRunLoopCallback(std::string_view eventName, CBCallback callback) {
-  chainblocks::Globals::RunLoopHooks[eventName] = callback;
+  chainblocks::GetGlobals().RunLoopHooks[eventName] = callback;
 }
 
 void unregisterRunLoopCallback(std::string_view eventName) {
-  auto findIt = chainblocks::Globals::RunLoopHooks.find(eventName);
-  if (findIt != chainblocks::Globals::RunLoopHooks.end()) {
-    chainblocks::Globals::RunLoopHooks.erase(findIt);
+  auto findIt = chainblocks::GetGlobals().RunLoopHooks.find(eventName);
+  if (findIt != chainblocks::GetGlobals().RunLoopHooks.end()) {
+    chainblocks::GetGlobals().RunLoopHooks.erase(findIt);
   }
 }
 
 void registerExitCallback(std::string_view eventName, CBCallback callback) {
-  chainblocks::Globals::ExitHooks[eventName] = callback;
+  chainblocks::GetGlobals().ExitHooks[eventName] = callback;
 }
 
 void unregisterExitCallback(std::string_view eventName) {
-  auto findIt = chainblocks::Globals::ExitHooks.find(eventName);
-  if (findIt != chainblocks::Globals::ExitHooks.end()) {
-    chainblocks::Globals::ExitHooks.erase(findIt);
+  auto findIt = chainblocks::GetGlobals().ExitHooks.find(eventName);
+  if (findIt != chainblocks::GetGlobals().ExitHooks.end()) {
+    chainblocks::GetGlobals().ExitHooks.erase(findIt);
   }
 }
 
 void registerChain(CBChain *chain) {
   std::shared_ptr<CBChain> sc(chain);
-  chainblocks::Globals::GlobalChains[chain->name] = sc;
+  chainblocks::GetGlobals().GlobalChains[chain->name] = sc;
 }
 
 void unregisterChain(CBChain *chain) {
-  auto findIt = chainblocks::Globals::GlobalChains.find(chain->name);
-  if (findIt != chainblocks::Globals::GlobalChains.end()) {
-    chainblocks::Globals::GlobalChains.erase(findIt);
+  auto findIt = chainblocks::GetGlobals().GlobalChains.find(chain->name);
+  if (findIt != chainblocks::GetGlobals().GlobalChains.end()) {
+    chainblocks::GetGlobals().GlobalChains.erase(findIt);
   }
 }
 
 void callExitCallbacks() {
   // Iterate backwards
-  for (auto it = chainblocks::Globals::ExitHooks.begin();
-       it != chainblocks::Globals::ExitHooks.end(); ++it) {
+  for (auto it = chainblocks::GetGlobals().ExitHooks.begin();
+       it != chainblocks::GetGlobals().ExitHooks.end(); ++it) {
     it->second();
   }
 }
@@ -1746,8 +1746,8 @@ void error_handler(int err_sig) {
   case SIGINT:
   case SIGTERM:
     CBLOG_INFO("Exiting due to INT/TERM signal");
-    chainblocks::Globals::SigIntTerm++;
-    if (chainblocks::Globals::SigIntTerm > 5)
+    chainblocks::GetGlobals().SigIntTerm++;
+    if (chainblocks::GetGlobals().SigIntTerm > 5)
       std::exit(-1);
     spdlog::shutdown();
     break;
@@ -1778,13 +1778,33 @@ void error_handler(int err_sig) {
   std::raise(err_sig);
 }
 
+#if _WIN32
+#include "debugapi.h"
+static bool isDebuggerPresent() {
+  return (bool)IsDebuggerPresent();
+}
+#else
+#include <sys/types.h>
+#include <sys/ptrace.h>
+static bool isDebuggerPresent()
+{
+  if (ptrace(PTRACE_TRACEME, 0, 1, 0) < 0)
+    return true;
+  else
+    ptrace(PTRACE_DETACH, 0, 1, 0);
+  return false;
+}
+#endif
+
 void installSignalHandlers() {
-  std::signal(SIGINT, &error_handler);
-  std::signal(SIGTERM, &error_handler);
-  std::signal(SIGFPE, &error_handler);
-  std::signal(SIGILL, &error_handler);
-  std::signal(SIGABRT, &error_handler);
-  std::signal(SIGSEGV, &error_handler);
+  if(!isDebuggerPresent()) {
+    std::signal(SIGINT, &error_handler);
+    std::signal(SIGTERM, &error_handler);
+    std::signal(SIGFPE, &error_handler);
+    std::signal(SIGILL, &error_handler);
+    std::signal(SIGABRT, &error_handler);
+    std::signal(SIGSEGV, &error_handler);
+  }
 }
 
 Blocks &Blocks::block(std::string_view name, std::vector<Var> params) {
@@ -2045,6 +2065,11 @@ endOfChain:
 #endif
 }
 
+Globals& GetGlobals() {
+  static Globals globals;
+  return globals;
+}
+
 template <typename T>
 NO_INLINE void arrayGrow(T &arr, size_t addlen, size_t min_cap) {
   // safety check to make sure this is not a borrowed foreign array!
@@ -2094,13 +2119,13 @@ NO_INLINE void _destroyVarSlow(CBVar &var) {
     chainblocks::arrayFree(var.payload.seqValue);
   } break;
   case Table: {
-    assert(var.payload.tableValue.api == &Globals::TableInterface);
+    assert(var.payload.tableValue.api == &GetGlobals().TableInterface);
     assert(var.payload.tableValue.opaque);
     auto map = (CBMap *)var.payload.tableValue.opaque;
     delete map;
   } break;
   case CBType::Set: {
-    assert(var.payload.setValue.api == &Globals::SetInterface);
+    assert(var.payload.setValue.api == &GetGlobals().SetInterface);
     assert(var.payload.setValue.opaque);
     auto set = (CBHashSet *)var.payload.setValue.opaque;
     delete set;
@@ -2222,13 +2247,13 @@ NO_INLINE void _cloneVarSlow(CBVar &dst, const CBVar &src) {
     if (dst.valueType == Table) {
       if (src.payload.tableValue.opaque == dst.payload.tableValue.opaque)
         return;
-      assert(dst.payload.tableValue.api == &Globals::TableInterface);
+      assert(dst.payload.tableValue.api == &GetGlobals().TableInterface);
       map = (CBMap *)dst.payload.tableValue.opaque;
       map->clear();
     } else {
       destroyVar(dst);
       dst.valueType = Table;
-      dst.payload.tableValue.api = &Globals::TableInterface;
+      dst.payload.tableValue.api = &GetGlobals().TableInterface;
       map = new CBMap();
       dst.payload.tableValue.opaque = map;
     }
@@ -2247,13 +2272,13 @@ NO_INLINE void _cloneVarSlow(CBVar &dst, const CBVar &src) {
     if (dst.valueType == CBType::Set) {
       if (src.payload.setValue.opaque == dst.payload.setValue.opaque)
         return;
-      assert(dst.payload.setValue.api == &Globals::SetInterface);
+      assert(dst.payload.setValue.api == &GetGlobals().SetInterface);
       set = (CBHashSet *)dst.payload.setValue.opaque;
       set->clear();
     } else {
       destroyVar(dst);
       dst.valueType = CBType::Set;
-      dst.payload.setValue.api = &Globals::SetInterface;
+      dst.payload.setValue.api = &GetGlobals().SetInterface;
       set = new CBHashSet();
       dst.payload.setValue.opaque = set;
     }
@@ -2693,15 +2718,15 @@ void Serialization::varFree(CBVar &output) {
 }
 
 CBString getString(uint32_t crc) {
-  assert(chainblocks::Globals::CompressedStrings);
-  auto s = (*chainblocks::Globals::CompressedStrings)[crc].string;
+  assert(chainblocks::GetGlobals().CompressedStrings);
+  auto s = (*chainblocks::GetGlobals().CompressedStrings)[crc].string;
   return s != nullptr ? s : "";
 }
 
 void setString(uint32_t crc, CBString str) {
-  assert(chainblocks::Globals::CompressedStrings);
-  (*chainblocks::Globals::CompressedStrings)[crc].string = str;
-  (*chainblocks::Globals::CompressedStrings)[crc].crc = crc;
+  assert(chainblocks::GetGlobals().CompressedStrings);
+  (*chainblocks::GetGlobals().CompressedStrings)[crc].string = str;
+  (*chainblocks::GetGlobals().CompressedStrings)[crc].crc = crc;
 }
 }; // namespace chainblocks
 
@@ -2850,7 +2875,7 @@ bool cb_current_interface_loaded{false};
 CBCore cb_current_interface{};
 
 extern "C" {
-EXPORTED CBCore *__cdecl chainblocksInterface(uint32_t abi_version) {
+CBCore *__cdecl chainblocksInterface(uint32_t abi_version) {
   // for now we ignore abi_version
   if (cb_current_interface_loaded)
     return &cb_current_interface;
@@ -2989,14 +3014,14 @@ EXPORTED CBCore *__cdecl chainblocksInterface(uint32_t abi_version) {
 
   result->tableNew = []() noexcept {
     CBTable res;
-    res.api = &chainblocks::Globals::TableInterface;
+    res.api = &chainblocks::GetGlobals().TableInterface;
     res.opaque = new chainblocks::CBMap();
     return res;
   };
 
   result->setNew = []() noexcept {
     CBSet res;
-    res.api = &chainblocks::Globals::SetInterface;
+    res.api = &chainblocks::GetGlobals().SetInterface;
     res.opaque = new chainblocks::CBHashSet();
     return res;
   };
@@ -3143,8 +3168,8 @@ EXPORTED CBCore *__cdecl chainblocksInterface(uint32_t abi_version) {
   };
 
   result->getGlobalChain = [](CBString name) noexcept {
-    auto it = chainblocks::Globals::GlobalChains.find(name);
-    if (it != chainblocks::Globals::GlobalChains.end()) {
+    auto it = chainblocks::GetGlobals().GlobalChains.find(name);
+    if (it != chainblocks::GetGlobals().GlobalChains.end()) {
       return CBChain::weakRef(it->second);
     } else {
       return (CBChainRef) nullptr;
@@ -3152,13 +3177,13 @@ EXPORTED CBCore *__cdecl chainblocksInterface(uint32_t abi_version) {
   };
 
   result->setGlobalChain = [](CBString name, CBChainRef chain) noexcept {
-    chainblocks::Globals::GlobalChains[name] = CBChain::sharedFromRef(chain);
+    chainblocks::GetGlobals().GlobalChains[name] = CBChain::sharedFromRef(chain);
   };
 
   result->unsetGlobalChain = [](CBString name) noexcept {
-    auto it = chainblocks::Globals::GlobalChains.find(name);
-    if (it != chainblocks::Globals::GlobalChains.end()) {
-      chainblocks::Globals::GlobalChains.erase(it);
+    auto it = chainblocks::GetGlobals().GlobalChains.find(name);
+    if (it != chainblocks::GetGlobals().GlobalChains.end()) {
+      chainblocks::GetGlobals().GlobalChains.erase(it);
     }
   };
 
@@ -3201,11 +3226,11 @@ EXPORTED CBCore *__cdecl chainblocksInterface(uint32_t abi_version) {
   };
 
   result->getRootPath = []() noexcept {
-    return chainblocks::Globals::RootPath.c_str();
+    return chainblocks::GetGlobals().RootPath.c_str();
   };
 
   result->setRootPath = [](const char *p) noexcept {
-    chainblocks::Globals::RootPath = p;
+    chainblocks::GetGlobals().RootPath = p;
     chainblocks::loadExternalBlocks(p);
     std::filesystem::current_path(p);
   };
@@ -3220,7 +3245,7 @@ EXPORTED CBCore *__cdecl chainblocksInterface(uint32_t abi_version) {
 
   result->getBlocks = []() {
     CBStrings s{};
-    for (auto [name, _] : chainblocks::Globals::BlocksRegister) {
+    for (auto [name, _] : chainblocks::GetGlobals().BlocksRegister) {
       chainblocks::arrayPush(s, name.data());
     }
     return s;

--- a/src/core/runtime.cpp
+++ b/src/core/runtime.cpp
@@ -1780,14 +1780,13 @@ void error_handler(int err_sig) {
 
 #if _WIN32
 #include "debugapi.h"
-static bool isDebuggerPresent() {
-  return (bool)IsDebuggerPresent();
-}
+static bool isDebuggerPresent() { return (bool)IsDebuggerPresent(); }
+#elif __APPLE__
+static bool isDebuggerPresent() { return false; }
 #else
-#include <sys/types.h>
 #include <sys/ptrace.h>
-static bool isDebuggerPresent()
-{
+#include <sys/types.h>
+static bool isDebuggerPresent() {
   if (ptrace(PTRACE_TRACEME, 0, 1, 0) < 0)
     return true;
   else

--- a/src/core/runtime.hpp
+++ b/src/core/runtime.hpp
@@ -55,9 +55,9 @@ using CBTimeDiff = decltype(CBClock::now() - CBDuration(0.0));
   if (_suspend_state != CBChainState::Continue)                                \
   return Var::Empty
 
-#define CB_STOP() std::rethrow_exception(chainblocks::Globals::StopChainEx);
+#define CB_STOP() std::rethrow_exception(chainblocks::GetGlobals().StopChainEx);
 #define CB_RESTART()                                                           \
-  std::rethrow_exception(chainblocks::Globals::RestartChainEx);
+  std::rethrow_exception(chainblocks::GetGlobals().RestartChainEx);
 
 struct CBContext {
   CBContext(
@@ -642,7 +642,7 @@ inline void sleep(double seconds = -1.0, bool runCallbacks = true) {
   if (runCallbacks) {
     CBDuration sleepTime(seconds);
     auto pre = CBClock::now();
-    for (auto &cbinfo : Globals::RunLoopHooks) {
+    for (auto &cbinfo : GetGlobals().RunLoopHooks) {
       if (cbinfo.second) {
         cbinfo.second();
       }
@@ -776,7 +776,7 @@ struct CBNode : public std::enable_shared_from_this<CBNode> {
   bool tick(Observer observer, CBVar input = Var::Empty) {
     auto noErrors = true;
     _errors.clear();
-    if (Globals::SigIntTerm > 0) {
+    if (GetGlobals().SigIntTerm > 0) {
       terminate();
     } else {
       CBDuration now = CBClock::now().time_since_epoch();
@@ -1020,7 +1020,7 @@ struct Serialization {
 
       if (!map) {
         map = new CBMap();
-        output.payload.tableValue.api = &Globals::TableInterface;
+        output.payload.tableValue.api = &GetGlobals().TableInterface;
         output.payload.tableValue.opaque = map;
       }
 
@@ -1056,7 +1056,7 @@ struct Serialization {
 
       if (!set) {
         set = new CBHashSet();
-        output.payload.setValue.api = &Globals::SetInterface;
+        output.payload.setValue.api = &GetGlobals().SetInterface;
         output.payload.setValue.opaque = set;
       }
 
@@ -1246,8 +1246,8 @@ struct Serialization {
       uint64_t len;
       read((uint8_t *)&len, sizeof(uint64_t));
       if (len > 0) {
-        auto it = Globals::ObjectTypesRegister.find(id);
-        if (it != Globals::ObjectTypesRegister.end()) {
+        auto it = GetGlobals().ObjectTypesRegister.find(id);
+        if (it != GetGlobals().ObjectTypesRegister.end()) {
           auto &info = it->second;
           auto size = size_t(len);
           std::vector<uint8_t> data;

--- a/src/extra/desktop.win.cpp
+++ b/src/extra/desktop.win.cpp
@@ -664,7 +664,7 @@ struct SendKeyEvent : public SendKeyEventBase {
       }
 
       auto lparam = MapVirtualKey(vkCode, MAPVK_VK_TO_VSC) << 16;
-      lparam = lparam | (state == 0) ? 0x00000001 : 0xC0000001;
+      lparam = lparam | (state == 0 ? 0x00000001 : 0xC0000001);
       PostMessage(window, state == 0 ? WM_KEYDOWN : WM_KEYUP, vkCode, lparam);
     } else {
       INPUT keyboardEvent;

--- a/src/extra/gltf.cpp
+++ b/src/extra/gltf.cpp
@@ -663,8 +663,8 @@ struct Load : public BGFX::BaseConsumer {
           // retreive the maxBones setting here
           int maxBones = 0;
           {
-            std::unique_lock lock(Globals::SettingsMutex);
-            auto &vmaxBones = Globals::Settings["GLTF.MaxBones"];
+            std::unique_lock lock(GetGlobals().SettingsMutex);
+            auto &vmaxBones = GetGlobals().Settings["GLTF.MaxBones"];
             if (vmaxBones.valueType == CBType::None) {
               vmaxBones = Var(32);
             }
@@ -1418,8 +1418,8 @@ struct Draw : public BGFX::BaseConsumer {
       // retreive the maxBones setting here
       int maxBones = 0;
       {
-        std::unique_lock lock(Globals::SettingsMutex);
-        auto &vmaxBones = Globals::Settings["GLTF.MaxBones"];
+        std::unique_lock lock(GetGlobals().SettingsMutex);
+        auto &vmaxBones = GetGlobals().Settings["GLTF.MaxBones"];
         if (vmaxBones.valueType == CBType::None) {
           vmaxBones = Var(32);
         }

--- a/src/extra/imgui.cpp
+++ b/src/extra/imgui.cpp
@@ -1584,9 +1584,9 @@ struct Image : public Base {
       ImVec2 size = _size;
       size.x *= texture->width;
       size.y *= texture->height;
-      ::ImGui::Image(texture->handle, size);
+      ::ImGui::Image(ImTextureID(texture->handle.idx), size);
     } else {
-      ::ImGui::Image(texture->handle, _size);
+      ::ImGui::Image(ImTextureID(texture->handle.idx), _size);
     }
     return input;
   }

--- a/src/extra/runtime.cpp
+++ b/src/extra/runtime.cpp
@@ -54,11 +54,14 @@ extern void registerEmscriptenShaderCompiler();
 
 void cbInitExtras() {
   registerRustBlocks(chainblocksInterface(CHAINBLOCKS_CURRENT_ABI));
+
   Snappy::registerBlocks();
   Brotli::registerBlocks();
+  
 #ifdef __EMSCRIPTEN__
   registerEmscriptenShaderCompiler();
 #endif
+
   BGFX::registerBGFXBlocks();
   chainblocks::ImGui::registerImGuiBlocks();
   XR::registerBlocks();
@@ -66,6 +69,7 @@ void cbInitExtras() {
   Inputs::registerBlocks();
   Audio::registerBlocks();
   DSP::registerBlocks();
+  
 #ifdef _WIN32
   Desktop::registerDesktopBlocks();
 #endif

--- a/src/mal/Reader.cpp
+++ b/src/mal/Reader.cpp
@@ -165,7 +165,8 @@ static malValuePtr readForm(Tokeniser &tokeniser) {
     tokeniser.next();
     std::unique_ptr<malValueVec> items(new malValueVec);
     readList(tokeniser, items.get(), ")");
-    return VALUE_WITH_LINE(mal::list(mal::symbol("chainify"), mal::vector(items.release())));
+    return VALUE_WITH_LINE(
+        mal::list(mal::symbol("chainify"), mal::vector(items.release())));
   } else if (token == "{") {
     tokeniser.next();
     malValueVec items;

--- a/src/mal/Types.cpp
+++ b/src/mal/Types.cpp
@@ -400,7 +400,7 @@ String malString::print(bool readably) const {
 malValuePtr malSymbol::eval(malEnvPtr env) {
   try {
     return env->get(value());
-  } catch(String &s) {
+  } catch (String &s) {
     s += ", line: " + std::to_string(line);
     throw;
   }

--- a/src/mal/Validation.cpp
+++ b/src/mal/Validation.cpp
@@ -5,26 +5,29 @@
 #include "Types.h"
 
 int checkArgsIs(const char *name, int expected, int got, malValuePtr val) {
-  MAL_CHECK(got == expected, "\"%s\" expects %d arg%s, %d supplied, line: %u", name,
-            expected, PLURAL(expected), got, val->line);
+  MAL_CHECK(got == expected, "\"%s\" expects %d arg%s, %d supplied, line: %u",
+            name, expected, PLURAL(expected), got, val->line);
   return got;
 }
 
-int checkArgsBetween(const char *name, int min, int max, int got, malValuePtr val) {
+int checkArgsBetween(const char *name, int min, int max, int got,
+                     malValuePtr val) {
   MAL_CHECK((got >= min) && (got <= max),
-            "\"%s\" expects between %d and %d arg%s, %d supplied, line: %u", name, min,
-            max, PLURAL(max), got, val->line);
+            "\"%s\" expects between %d and %d arg%s, %d supplied, line: %u",
+            name, min, max, PLURAL(max), got, val->line);
   return got;
 }
 
 int checkArgsAtLeast(const char *name, int min, int got, malValuePtr val) {
-  MAL_CHECK(got >= min, "\"%s\" expects at least %d arg%s, %d supplied, line: %u", name,
+  MAL_CHECK(got >= min,
+            "\"%s\" expects at least %d arg%s, %d supplied, line: %u", name,
             min, PLURAL(min), got, val->line);
   return got;
 }
 
 int checkArgsEven(const char *name, int got, malValuePtr val) {
-  MAL_CHECK(got % 2 == 0, "\"%s\" expects an even number of args, %d supplied, line: %u",
+  MAL_CHECK(got % 2 == 0,
+            "\"%s\" expects an even number of args, %d supplied, line: %u",
             name, got, val->line);
   return got;
 }

--- a/src/tests/test_extra.cpp
+++ b/src/tests/test_extra.cpp
@@ -14,7 +14,7 @@
 #include <catch2/catch_all.hpp>
 
 int main(int argc, char *argv[]) {
-  chainblocks::Globals::RootPath = "./";
+  chainblocks::GetGlobals().RootPath = "./";
   registerCoreBlocks();
   int result = Catch::Session().run(argc, argv);
 #ifdef __EMSCRIPTEN_PTHREADS__

--- a/src/tests/test_runtime.cpp
+++ b/src/tests/test_runtime.cpp
@@ -15,7 +15,7 @@
 #include <catch2/catch_all.hpp>
 
 int main(int argc, char *argv[]) {
-  chainblocks::Globals::RootPath = "./";
+  chainblocks::GetGlobals().RootPath = "./";
   registerCoreBlocks();
   int result = Catch::Session().run(argc, argv);
   return result;
@@ -833,7 +833,7 @@ TEST_CASE("CBMap") {
   CBVar vx{};
   vx.valueType = CBType::Table;
   vx.payload.tableValue.opaque = &x;
-  vx.payload.tableValue.api = &Globals::TableInterface;
+  vx.payload.tableValue.api = &GetGlobals().TableInterface;
 
   CBMap y;
   y.emplace("y", Var("Hello Set"));
@@ -842,7 +842,7 @@ TEST_CASE("CBMap") {
   CBVar vy{};
   vy.valueType = CBType::Table;
   vy.payload.tableValue.opaque = &y;
-  vy.payload.tableValue.api = &Globals::TableInterface;
+  vy.payload.tableValue.api = &GetGlobals().TableInterface;
 
   CBMap z;
   z.emplace("y", Var("Hello Set"));
@@ -851,7 +851,7 @@ TEST_CASE("CBMap") {
   CBVar vz{};
   vz.valueType = CBType::Table;
   vz.payload.tableValue.opaque = &z;
-  vz.payload.tableValue.api = &Globals::TableInterface;
+  vz.payload.tableValue.api = &GetGlobals().TableInterface;
 
   REQUIRE(vx == vy);
 
@@ -886,7 +886,7 @@ TEST_CASE("CBHashSet") {
   CBVar vx{};
   vx.valueType = CBType::Set;
   vx.payload.setValue.opaque = &x;
-  vx.payload.setValue.api = &Globals::SetInterface;
+  vx.payload.setValue.api = &GetGlobals().SetInterface;
 
   CBHashSet y;
   y.emplace(Var("Hello Set"));
@@ -895,7 +895,7 @@ TEST_CASE("CBHashSet") {
   CBVar vy{};
   vy.valueType = CBType::Set;
   vy.payload.setValue.opaque = &y;
-  vy.payload.setValue.api = &Globals::SetInterface;
+  vy.payload.setValue.api = &GetGlobals().SetInterface;
 
   CBHashSet z;
   z.emplace(Var("Hello Set"));
@@ -904,7 +904,7 @@ TEST_CASE("CBHashSet") {
   CBVar vz{};
   vz.valueType = CBType::Set;
   vz.payload.setValue.opaque = &z;
-  vz.payload.setValue.api = &Globals::SetInterface;
+  vz.payload.setValue.api = &GetGlobals().SetInterface;
 
   REQUIRE(vx == vy);
   REQUIRE(vx != vz);


### PR DESCRIPTION
Some code-only changes extracted from the cmake branch.

Most of these were encountered when compiling with clang.
It doesn't fix everything but it compiles and doesn't crash on startup

- Change wasm3 module to https://github.com/chainblocks/wasm3.git (main branch)
- Global initialization order fix for clang
- Missing header  \<optional\>
- Missing inline in header function
- Explicit usage of CBType values where they're ambiguous
- EXPORT macro in source file
- Don't install signal handlers when a debugger is attached
- make "Overriding enum type" a debug log so it doesn't show up on stdout during test discovery