### PR TITLE
Update mkdocs.yml to change page's header text case from sentence-title to title-case

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -1,6 +1,6 @@
 edit_uri: ''
 repo_url: https://github.com/fragcolor-xyz/chainblocks/
-site_name: Fragcolor documentation
+site_name: Fragcolor Documentation
 site_url: https://docs.fragcolor.xyz
 copyright: Copyright © 2021 Fragcolor Pte. Ltd.
 extra:


### PR DESCRIPTION
Change the text case of the header title text 'Fragcolor documentation' from sentence-case to 'Fragcolor Documentation' i.e. title-case.