### PR TITLE
Disable the rust cache only on manual workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -162,7 +162,7 @@ jobs:
       - uses: Swatinem/rust-cache@v1
         if: ${{ github.event_name != 'workflow_dispatch' }}
         with:
-          key: ${{ matrix.build-type }}
+          sharedKey: Linux-${{ matrix.build-type }}
       - name: Build
         run: |
           mkdir build
@@ -200,6 +200,8 @@ jobs:
           rustup update
       - uses: Swatinem/rust-cache@v1
         if: ${{ matrix.build-type == 'Debug' && github.event_name != 'workflow_dispatch' }}
+        with:
+          sharedKey: Linux-${{ matrix.build-type }}
       - name: Build (Debug)
         if: ${{ matrix.build-type == 'Debug' }}
         run: |
@@ -335,7 +337,7 @@ jobs:
       - uses: Swatinem/rust-cache@v1
         if: ${{ github.event_name != 'workflow_dispatch' }}
         with:
-          key: ${{ matrix.test-tags }}
+          sharedKey: Linux-Debug
       - name: Build
         run: |
           cd build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,7 +55,7 @@ jobs:
         run: |
           rustup component add rust-src --toolchain nightly
       - uses: Swatinem/rust-cache@v1
-        if: ${{ github.event_name == 'pull_request' }}
+        if: ${{ github.event_name != 'workflow_dispatch' }}
         with:
           key: ${{ matrix.threading }}
       - name: Build
@@ -160,7 +160,7 @@ jobs:
           sudo apt-get -y install build-essential git cmake wget clang ninja-build libboost-all-dev xorg-dev libdbus-1-dev libssl-dev mesa-utils
           rustup update
       - uses: Swatinem/rust-cache@v1
-        if: ${{ github.event_name == 'pull_request' }}
+        if: ${{ github.event_name != 'workflow_dispatch' }}
         with:
           key: ${{ matrix.build-type }}
       - name: Build
@@ -199,7 +199,7 @@ jobs:
           sudo apt-get -y install build-essential git cmake wget clang ninja-build libboost-all-dev xorg-dev libdbus-1-dev libssl-dev lcov mesa-utils
           rustup update
       - uses: Swatinem/rust-cache@v1
-        if: ${{ matrix.build-type == 'Debug' && github.event_name == 'pull_request' }}
+        if: ${{ matrix.build-type == 'Debug' && github.event_name != 'workflow_dispatch' }}
       - name: Build (Debug)
         if: ${{ matrix.build-type == 'Debug' }}
         run: |
@@ -333,7 +333,7 @@ jobs:
           cp ../../src/extra/shaders/gltf/*.* lib/gltf/
           cp ../../src/extra/shaders/include/*.* include/
       - uses: Swatinem/rust-cache@v1
-        if: ${{ github.event_name == 'pull_request' }}
+        if: ${{ github.event_name != 'workflow_dispatch' }}
         with:
           key: ${{ matrix.test-tags }}
       - name: Build
@@ -485,7 +485,7 @@ jobs:
           rustup update
           rustup default stable-${{ matrix.arch }}-pc-windows-gnu
       - uses: Swatinem/rust-cache@v1
-        if: ${{ github.event_name == 'pull_request' }}
+        if: ${{ github.event_name != 'workflow_dispatch' }}
         with:
           key: ${{ matrix.build-type }}
       - name: Set up MSYS2
@@ -823,7 +823,7 @@ jobs:
           brew install openssl@1.1
           rustup update
       - uses: Swatinem/rust-cache@v1
-        if: ${{ github.event_name == 'pull_request' }}
+        if: ${{ github.event_name != 'workflow_dispatch' }}
         with:
           key: ${{ matrix.build-type }}
       - name: Build
@@ -928,7 +928,7 @@ jobs:
           rustup target add x86_64-apple-ios
           rustup target add aarch64-apple-ios
       - uses: Swatinem/rust-cache@v1
-        if: ${{ github.event_name == 'pull_request' }}
+        if: ${{ github.event_name != 'workflow_dispatch' }}
       - name: Build device
         run: |
           cmake -Bbuild -GXcode -DBOOST_ROOT=`brew --prefix boost` -DCMAKE_BUILD_TYPE=Debug -DCMAKE_SYSTEM_NAME=iOS


### PR DESCRIPTION
Executables built was the cache is active have been checked to work on Windows. So we will try to keep the cache always on except on manually triggered workflows so that we have a workaround just in case.