### PR TITLE
Replace file used for audio testing

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -216,7 +216,7 @@ jobs:
       - name: Get sample files
         run: |
           mkdir external && cd external
-          wget https://file-examples-com.github.io/uploads/2017/11/file_example_OOG_1MG.ogg
+          wget -nv https://bafybeifsdqdnhjk4triskonqqin2jvylfcwbdqhvrpsc4oxjgbwgle7ipe.ipfs.nftstorage.link -O Ode_to_Joy.ogg
       - name: Test
         env:
           RUST_BACKTRACE: 1
@@ -875,7 +875,7 @@ jobs:
       - name: Get sample files
         run: |
           mkdir external && cd external
-          wget https://file-examples-com.github.io/uploads/2017/11/file_example_OOG_1MG.ogg
+          wget -nv https://bafybeifsdqdnhjk4triskonqqin2jvylfcwbdqhvrpsc4oxjgbwgle7ipe.ipfs.nftstorage.link -O Ode_to_Joy.ogg
       - name: Test
         env:
           RUST_BACKTRACE: 1

--- a/src/tests/audio.edn
+++ b/src/tests/audio.edn
@@ -4,7 +4,7 @@
 (defnode main)
 
 (defloop play-files
-  (Audio.ReadFile "../../external/file_example_OOG_1MG.ogg" :From 1.0 :To 1.023219954648526)
+  (Audio.ReadFile "../../external/Ode_to_Joy.ogg" :From 1.0 :To 1.023219954648526)
   (Log))
 
 (schedule main play-files)
@@ -13,7 +13,7 @@
 (run main)
 
 (defloop play-file-fft
-  (Audio.ReadFile "../../external/file_example_OOG_1MG.ogg" :Channels 1 :From 5.0 :To 6.0)
+  (Audio.ReadFile "../../external/Ode_to_Joy.ogg" :Channels 1 :From 5.0 :To 6.0)
   (DSP.FFT) = .freq-domain
   (DSP.IFFT :Audio true)
   (Audio.WriteFile "example-fft.wav" :Channels 1)
@@ -27,7 +27,7 @@
 (run main)
 
 ;; (defloop play-file-dwt
-;;   (Audio.ReadFile "../../external/file_example_OOG_1MG.ogg" :Channels 1 :From 5.0 :To 6.0)
+;;   (Audio.ReadFile "../../external/Ode_to_Joy.ogg" :Channels 1 :From 5.0 :To 6.0)
 ;;   (DSP.Wavelet)
 ;;   (DSP.InverseWavelet)
 ;;   (Audio.WriteFile "example-dwt.wav" :Channels 1))
@@ -44,7 +44,7 @@
 
 (defloop device-test
   (Audio.Device)
-  (Audio.Channel :Blocks (-> (Audio.ReadFile "../../external/file_example_OOG_1MG.ogg"
+  (Audio.Channel :Blocks (-> (Audio.ReadFile "../../external/Ode_to_Joy.ogg"
                                              :Channels 2
                                              :From 4.0 :To 6.0))))
 


### PR DESCRIPTION
Files comes from https://commons.wikimedia.org/wiki/File:Ode_to_Joy.ogg (public domain)