### PR TITLE
Enhance documentation for existing and undocumented functions

### DIFF
--- a/docs/docs/functions/macros.md
+++ b/docs/docs/functions/macros.md
@@ -140,7 +140,7 @@ A node is a self-contained execution-context and software environment (like a se
 
 Defines a new looped chain.
 
-`(defchain my-loop)` is actually a shorthand for the more verbose looped chain definition.
+`(defloop my-loop)` is actually a shorthand for the more verbose looped chain definition.
 === "Code"
 
     ```clojure linenums="1"

--- a/docs/docs/functions/macros.md
+++ b/docs/docs/functions/macros.md
@@ -95,7 +95,7 @@ Defines a new macro.
 
 Defines a new node on which chains can be scheduled (to run).
 
-A node is a self-contained execution-context and software environment (like a server) that executes the chain code logic. It can run both on the local hardware as well as  peer-to-peer hardware over the network (blockchain). 
+A node is a self-contained execution-context and software environment (like a server) that executes the chain code logic. It can run both on the local hardware as well as peer-to-peer hardware over the network (blockchain). 
 
 === "Code"
 
@@ -111,8 +111,8 @@ A node is a self-contained execution-context and software environment (like a se
     ;; schedule both the chains on this node
     (schedule main chain-hi)
     (schedule main chain-bye)
-    ;; run all the scheduled chains on this node (FPS and iterations apply only to looped chains)
-    (run main 0.02 5)
+    ;; run all the scheduled chains on this node
+    (run main 0.02)
     ```
 === "Result"
 

--- a/docs/docs/functions/macros.md
+++ b/docs/docs/functions/macros.md
@@ -129,10 +129,37 @@ A node is a self-contained execution-context and software environment (like a se
 
 Defines a new chain that is looped.
 
+Such a chain, when invoked (via `run <node>`), executes in a loop at the frequency given by the 2nd parameter of the `run` command and for a number of iterations specified by the 3rd parameter of the `run`command.
+
 === "Code"
 
     ```clojure linenums="1"
+    (defnode main)
+    ;; define a looped chain (chain-hello)
+    (defloop chain-hi
+        (Msg "Hello World!"))
+    ;; define another looped chain (chain-bye)
+    (defloop chain-bye
+        (Msg "Goodbye World"))
+    ;; schedule the looped chains on this node
+    (schedule main chain-hi)
+    (schedule main chain-bye)
+    ;; run all the chains on this node at 50 FPS and for a max 5 iterations
+    (run main 0.02 5)
+    ```
+=== "Result"
 
+    ```
+    [info] [2022-03-07 22:28:54.682] [T-8432] [logging.cpp::94] [chain-hi] Hello World!
+    [info] [2022-03-07 22:28:54.682] [T-8432] [logging.cpp::94] [chain-bye] Goodbye World
+    [info] [2022-03-07 22:28:54.715] [T-8432] [logging.cpp::94] [chain-hi] Hello World!
+    [info] [2022-03-07 22:28:54.715] [T-8432] [logging.cpp::94] [chain-bye] Goodbye World
+    [info] [2022-03-07 22:28:54.731] [T-8432] [logging.cpp::94] [chain-hi] Hello World!
+    [info] [2022-03-07 22:28:54.732] [T-8432] [logging.cpp::94] [chain-bye] Goodbye World
+    [info] [2022-03-07 22:28:54.746] [T-8432] [logging.cpp::94] [chain-hi] Hello World!
+    [info] [2022-03-07 22:28:54.747] [T-8432] [logging.cpp::94] [chain-bye] Goodbye World
+    [info] [2022-03-07 22:28:54.763] [T-8432] [logging.cpp::94] [chain-hi] Hello World!
+    [info] [2022-03-07 22:28:54.763] [T-8432] [logging.cpp::94] [chain-bye] Goodbye World
     ```
 
 ??? info "See also"

--- a/docs/docs/functions/macros.md
+++ b/docs/docs/functions/macros.md
@@ -93,12 +93,36 @@ Defines a new macro.
 
 ## defnode
 
-Defines a new node on which chains can be scheduled.
+Defines a new node on which chains can be scheduled (to run).
+
+A node is a self-contained execution-context and software environment (like a server) that executes the chain code logic. It can run both on the local hardware as well as  peer-to-peer hardware over the network (blockchain). 
 
 === "Code"
 
     ```clojure linenums="1"
+    ;; define a node (main)
     (defnode main)
+    ;; define a looped chain
+    (defloop chain-hi
+        (Msg "Hello World!"))
+    ;; define a non-looped chain
+    (defchain chain-bye
+        (Msg "Goodbye World"))
+    ;; schedule both the chains on this node
+    (schedule main chain-hi)
+    (schedule main chain-bye)
+    ;; run all the scheduled chains on this node (FPS and iterations apply only to looped chains)
+    (run main 0.02 5)
+    ```
+=== "Result"
+
+    ```
+    [info] [2022-03-07 22:14:51.730] [T-14836] [logging.cpp::94] [chain-hi] Hello World!
+    [info] [2022-03-07 22:14:51.731] [T-14836] [logging.cpp::94] [chain-bye] Goodbye World
+    [info] [2022-03-07 22:14:51.760] [T-14836] [logging.cpp::94] [chain-hi] Hello World!
+    [info] [2022-03-07 22:14:51.776] [T-14836] [logging.cpp::94] [chain-hi] Hello World!
+    [info] [2022-03-07 22:14:51.791] [T-14836] [logging.cpp::94] [chain-hi] Hello World!
+    [info] [2022-03-07 22:14:51.823] [T-14836] [logging.cpp::94] [chain-hi] Hello World!
     ```
 
 ## defloop

--- a/docs/docs/functions/macros.md
+++ b/docs/docs/functions/macros.md
@@ -39,10 +39,33 @@ Defines new blocks that can be inserted into an existing chain.
 
 Defines a new chain that isn't looped.
 
+Such a chain executes only once when invoked (via `run <node>`).
+
 === "Code"
 
     ```clojure linenums="1"
+    ;; define a node (main)
+    (defnode main)
+    ;; define a non-looped chain (chain-hello)
+    (defchain chain-hello
+        (Msg "Hello World!"))
+    ;; define another non-looped chain (chain-bye)
+    (defchain chain-bye
+        (Msg "Goodbye World"))
+    ;; schedule the non-looped chains on the node
+    (schedule main chain-hello)
+    (schedule main chain-bye)
+    ;; run all the scheduled chains on the node
+    (run main)
+    ;; Even if provided, the FPS and iteration parameters are ignored for non-looped chains
+    ;; (run main 0.02 5)
+    ```
 
+=== "Result"
+
+    ```
+    [info] [2022-03-07 20:45:35.681] [T-9044] [logging.cpp::94] [chain-hello] Hello World!
+    [info] [2022-03-07 20:45:35.678] [T-9044] [logging.cpp::94] [chain-bye] Goodbye World
     ```
 
 ??? info "See also"

--- a/docs/docs/functions/macros.md
+++ b/docs/docs/functions/macros.md
@@ -37,9 +37,22 @@ Defines new blocks that can be inserted into an existing chain.
 
 ## defchain
 
-Defines a new chain that isn't looped.
+Defines a new non-looped chain.
 
-Such a chain executes only once when invoked (via `run <node>`).
+`(defchain my-chain)` is actually a shorthand for the more verbose non-looped chain definition.
+=== "Code"
+
+    ```clojure linenums="1"
+    ;; defchain
+    (def my-chain
+    (Chain "my-chain"
+        ;; blocks here
+    ))
+    ```
+
+For a chain to be executed, it must first be scheduled on a `node` and then that that node needs to run.
+
+A node will execute a non-looped chain only once (even though node itself may continue running).
 
 === "Code"
 
@@ -57,8 +70,6 @@ Such a chain executes only once when invoked (via `run <node>`).
     (schedule main chain-bye)
     ;; run all the scheduled chains on the node
     (run main)
-    ;; Even if provided, the FPS and iteration parameters are ignored for non-looped chains
-    ;; (run main 0.02 5)
     ```
 
 === "Result"
@@ -93,7 +104,7 @@ Defines a new macro.
 
 ## defnode
 
-Defines a new node on which chains can be scheduled (to run).
+Defines a new `node` on which chains can be scheduled and then run.
 
 A node is a self-contained execution-context and software environment (like a server) that executes the chain code logic. It can run both on the local hardware as well as peer-to-peer hardware over the network (blockchain). 
 
@@ -112,7 +123,7 @@ A node is a self-contained execution-context and software environment (like a se
     (schedule main chain-hi)
     (schedule main chain-bye)
     ;; run all the scheduled chains on this node
-    (run main 0.02)
+    (run main)
     ```
 === "Result"
 
@@ -127,9 +138,22 @@ A node is a self-contained execution-context and software environment (like a se
 
 ## defloop
 
-Defines a new chain that is looped.
+Defines a new looped chain.
 
-Such a chain, when invoked (via `run <node>`), executes in a loop at the frequency given by the 2nd parameter of the `run` command and for a number of iterations specified by the 3rd parameter of the `run`command.
+`(defchain my-loop)` is actually a shorthand for the more verbose looped chain definition.
+=== "Code"
+
+    ```clojure linenums="1"
+    ;; defloop
+    (def my-loop
+    (Chain "my-loop" :Looped
+        ;; blocks here
+    ))
+    ```
+    
+For a chain to be executed, it must first be scheduled on a `node` and then that that node needs to run.
+
+A node will continue executing a looped chain till the node itself stops running (or the chain execution is stopped via a logic condition).
 
 === "Code"
 
@@ -144,8 +168,8 @@ Such a chain, when invoked (via `run <node>`), executes in a loop at the frequen
     ;; schedule the looped chains on this node
     (schedule main chain-hi)
     (schedule main chain-bye)
-    ;; run all the chains on this node at 50 FPS and for a max 5 iterations
-    (run main 0.02 5)
+    ;; run all the chains on this node
+    (run main)
     ```
 === "Result"
 

--- a/docs/docs/functions/misc.md
+++ b/docs/docs/functions/misc.md
@@ -115,6 +115,39 @@ Executes all the chains that have been scheduled on a given node.
     [info] [2022-03-07 21:42:12.413] [T-18096] [logging.cpp::94] [chain-hi] Hello World!
     ```
 
+## schedule
+
+Queues a chain for execution on a given node.
+
+=== "Code"
+
+    ```clojure linenums="1"
+    ;; define a node (main)
+    (defnode main)
+    ;; define a looped chain
+    (defloop chain-hi
+        (Msg "Hello World!"))
+    ;; define a non-looped chain
+    (defchain chain-bye
+        (Msg "Goodbye World"))
+    ;; schedule both the chains on this node
+    (schedule main chain-hi)
+    (schedule main chain-bye)
+    ;; run all the scheduled chains on this loop (main)
+    (run main 0.02 5)
+    ```
+
+=== "Result"
+
+    ```
+    [info] [2022-03-07 21:42:12.324] [T-18096] [logging.cpp::94] [chain-hi] Hello World!
+    [info] [2022-03-07 21:42:12.325] [T-18096] [logging.cpp::94] [chain-bye] Goodbye World
+    [info] [2022-03-07 21:42:12.351] [T-18096] [logging.cpp::94] [chain-hi] Hello World!
+    [info] [2022-03-07 21:42:12.367] [T-18096] [logging.cpp::94] [chain-hi] Hello World!
+    [info] [2022-03-07 21:42:12.397] [T-18096] [logging.cpp::94] [chain-hi] Hello World!
+    [info] [2022-03-07 21:42:12.413] [T-18096] [logging.cpp::94] [chain-hi] Hello World!
+    ```
+
 ## swap!
 
 ```clojure linenums="1"

--- a/docs/docs/functions/misc.md
+++ b/docs/docs/functions/misc.md
@@ -74,6 +74,47 @@ license: CC-BY-SA-4.0
 
 ```
 
+## run
+
+Executes all the chains that have been scheduled on a given node.
+
+`run` takes three arguments: the name of the node, number of seconds to elapse between chain executions, and the maximum number of chain executions allowed. 
+
+*The last two arguments apply only to looped (defloop) chains and are ignored for other (defchain) chains.*
+
+=== "Code"
+
+    ```clojure linenums="1"
+    ;; define a node (main)
+    (defnode main)
+    ;; define a looped chain
+    (defloop chain-hi
+        (Msg "Hello World!"))
+    ;; define a non-looped chain
+    (defchain chain-bye
+        (Msg "Goodbye World"))
+    ;; schedule both the chains on this node
+    (schedule main chain-hi)
+    (schedule main chain-bye)
+    ;; run the scheduled chains:
+    ;; 1. the looped chain will run once every 0.02 secs (i.e. at 50 FPS) and for 5 iterations
+    ;; 2. the non-looped chain will run only once (FPS and iterations are ignored)
+    (run main 0.02 5)
+    ;; The last two args may also be passed as mathematical expressions
+    ;; (run main (/ 1 50) (+ 2 3))
+    ```
+
+=== "Result"
+
+    ```
+    [info] [2022-03-07 21:42:12.324] [T-18096] [logging.cpp::94] [chain-hi] Hello World!
+    [info] [2022-03-07 21:42:12.325] [T-18096] [logging.cpp::94] [chain-bye] Goodbye World
+    [info] [2022-03-07 21:42:12.351] [T-18096] [logging.cpp::94] [chain-hi] Hello World!
+    [info] [2022-03-07 21:42:12.367] [T-18096] [logging.cpp::94] [chain-hi] Hello World!
+    [info] [2022-03-07 21:42:12.397] [T-18096] [logging.cpp::94] [chain-hi] Hello World!
+    [info] [2022-03-07 21:42:12.413] [T-18096] [logging.cpp::94] [chain-hi] Hello World!
+    ```
+
 ## swap!
 
 ```clojure linenums="1"

--- a/docs/docs/functions/misc.md
+++ b/docs/docs/functions/misc.md
@@ -76,11 +76,11 @@ license: CC-BY-SA-4.0
 
 ## run
 
-Executes all the chains that have been scheduled on a given node.
+Executes all the chains that have been scheduled on a given `node`.
 
-`run` takes three arguments: the name of the node, number of seconds to elapse between chain executions, and the maximum number of chain executions allowed. 
+`(run <params>)` takes two arguments: name of the node, and node iteration interval (no. of seconds between two node iterations).
 
-*The last two arguments apply only to looped (defloop) chains and are ignored for other (defchain) chains.*
+*An optional 3rd argument defines the maximum node iterations to run. This argument is a debug parameter - do not use for production.*
 
 === "Code"
 
@@ -96,11 +96,11 @@ Executes all the chains that have been scheduled on a given node.
     ;; schedule both the chains on this node
     (schedule main chain-hi)
     (schedule main chain-bye)
-    ;; run the scheduled chains:
-    ;; 1. the looped chain will run once every 0.02 secs (i.e. at 50 FPS) and for 5 iterations
-    ;; 2. the non-looped chain will run only once (FPS and iterations are ignored)
+    ;; run the node to execute scheduled chains
+    ;; time between node iterations - 0.02 secs
+    ;; max node iterations allowed - 5
     (run main 0.02 5)
-    ;; The last two args may also be passed as mathematical expressions
+    ;; The last two args  may also be passed as mathematical expressions
     ;; (run main (/ 1 50) (+ 2 3))
     ```
 
@@ -119,6 +119,8 @@ Executes all the chains that have been scheduled on a given node.
 
 Queues a chain for execution on a given node.
 
+Multiple chains can be scheduled on the same `node`. When a node is run, all the chains on it are executed.
+
 === "Code"
 
     ```clojure linenums="1"
@@ -133,8 +135,8 @@ Queues a chain for execution on a given node.
     ;; schedule both the chains on this node
     (schedule main chain-hi)
     (schedule main chain-bye)
-    ;; run all the scheduled chains on this loop (main)
-    (run main 0.02 5)
+    ;; run all the scheduled chains on this node (main)
+    (run main)
     ```
 
 === "Result"


### PR DESCRIPTION
Add description and code samples for the following functions:
> `defchain`
> `defnode`
> `defloop`
> `run`
> `schedule`