### PR TITLE
Doc: display sample's output

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -9,10 +9,10 @@ jobs:
   # Build chainblocks for Windows
   #
   Windows:
-    runs-on: windows-latest
+    runs-on: windows-2019
     strategy:
       matrix:
-        build-type: ["Debug"]
+        build-type: ["Debug", "Release"]
         bitness: [64bits]
         include:
           - bitness: 64bits
@@ -32,6 +32,8 @@ jobs:
           rustup update
           rustup default stable-${{ matrix.arch }}-pc-windows-gnu
       - uses: Swatinem/rust-cache@v1
+        with:
+          key: ${{ matrix.build-type }}
       - name: Set up MSYS2
         uses: msys2/setup-msys2@v2
         with:
@@ -68,16 +70,16 @@ jobs:
   #
   docs-samples:
     needs: Windows
-    runs-on: windows-latest
+    runs-on: windows-2019
     steps:
       - name: Checkout
         uses: actions/checkout@v2
         with:
           fetch-depth: 1
-      - name: Download artifact
+      - name: Download cbl
         uses: actions/download-artifact@v2
         with:
-          name: cbl-win64 Debug
+          name: cbl-win64 Release
           path: docs/samples
       - name: Set up MSYS2
         uses: msys2/setup-msys2@v2
@@ -85,8 +87,6 @@ jobs:
           msystem: MINGW64
           release: false
           path-type: inherit
-          install: >-
-            mingw-w64-x86_64-boost
       - name: Run samples
         shell: msys2 {0}
         run: |
@@ -94,21 +94,27 @@ jobs:
           for i in $(find blocks -name '*.edn');
           do
             echo "Running sample $i";
-            ./cbl.exe run_sample.edn --file "$i";
+            ./cbl.exe run_sample.edn --file "$i" > >(tee "$i.log");
           done
+      - name: Upload samples logs
+        uses: actions/upload-artifact@v2
+        with:
+          name: samples-logs
+          path: docs/samples/**/*.log
+          if-no-files-found: error
 
   #
   # Generate blocks documentation (markdown)
   #
   docs-markdown:
     needs: Windows
-    runs-on: windows-latest
+    runs-on: windows-2019
     steps:
       - name: Checkout
         uses: actions/checkout@v2
         with:
           fetch-depth: 1
-      - name: Download artifact
+      - name: Download cbl
         uses: actions/download-artifact@v2
         with:
           name: cbl-win64 Debug
@@ -123,7 +129,7 @@ jobs:
       - name: Generate markdown
         shell: msys2 {0}
         run: ./cbl.exe src/tests/infos_docs.edn
-      - name: Upload artifact
+      - name: Upload markdown
         uses: actions/upload-artifact@v2
         with:
           name: docs-markdown
@@ -136,7 +142,7 @@ jobs:
   # Build documentation website
   #
   docs-website-build:
-    needs: docs-markdown
+    needs: [docs-markdown, docs-samples]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -152,11 +158,16 @@ jobs:
           pip install mkdocs-material
           pip install mkdocs-awesome-pages-plugin
           pip install mkdocs-macros-plugin
-      - name: Download artifact
+      - name: Download markdown
         uses: actions/download-artifact@v2
         with:
           name: docs-markdown
           path: docs/docs/blocks
+      - name: Download samples logs
+        uses: actions/download-artifact@v2
+        with:
+          name: samples-logs
+          path: docs/samples
       - name: Build website
         run: |
           cd docs

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -656,10 +656,10 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 1
-      - name: Download artifact
+      - name: Download cbl
         uses: actions/download-artifact@v2
         with:
-          name: cbl-win64 Debug
+          name: cbl-win64 Release
           path: docs/samples
       - name: Set up MSYS2
         uses: msys2/setup-msys2@v2
@@ -667,8 +667,6 @@ jobs:
           msystem: MINGW64
           release: false
           path-type: inherit
-          install: >-
-            mingw-w64-x86_64-boost
       - name: Run samples
         shell: msys2 {0}
         run: |
@@ -676,8 +674,14 @@ jobs:
           for i in $(find blocks -name '*.edn');
           do
             echo "Running sample $i";
-            ./cbl.exe run_sample.edn --file "$i";
+            ./cbl.exe run_sample.edn --file "$i" > >(tee "$i.log");
           done
+      - name: Upload samples logs
+        uses: actions/upload-artifact@v2
+        with:
+          name: samples-logs
+          path: docs/samples/**/*.log
+          if-no-files-found: error
 
   #
   # Generate blocks documentation (markdown)
@@ -690,7 +694,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 1
-      - name: Download artifact
+      - name: Download cbl
         uses: actions/download-artifact@v2
         with:
           name: cbl-win64 Debug
@@ -705,7 +709,7 @@ jobs:
       - name: Generate markdown
         shell: msys2 {0}
         run: ./cbl.exe src/tests/infos_docs.edn
-      - name: Upload artifact
+      - name: Upload markdown
         uses: actions/upload-artifact@v2
         with:
           name: docs-markdown
@@ -718,7 +722,7 @@ jobs:
   # Build documentation website
   #
   docs-website-build:
-    needs: docs-markdown
+    needs: [docs-markdown, docs-samples]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -734,11 +738,16 @@ jobs:
           pip install mkdocs-material
           pip install mkdocs-awesome-pages-plugin
           pip install mkdocs-macros-plugin
-      - name: Download artifact
+      - name: Download markdown
         uses: actions/download-artifact@v2
         with:
           name: docs-markdown
           path: docs/docs/blocks
+      - name: Download samples logs
+        uses: actions/download-artifact@v2
+        with:
+          name: samples-logs
+          path: docs/samples
       - name: Build website
         run: |
           cd docs

--- a/src/tests/infos_docs.edn
+++ b/src/tests/infos_docs.edn
@@ -131,12 +131,19 @@
 
      name (getFilename (str basePath samplePath) "") (FS.Iterate)
      (ForEach
-      (-> (| "=== \"Code\"\r\n\r\n" >> .o)
-          (| "    ```clojure linenums=\"1\"\r\n" >> .o)
-          (| "    --8<-- \"" >> .o name (getFilename samplePath "/") >> .o)
-          (FS.Filename) >> .o "\"\r\n" >> .o
-          "    ```\r\n" >> .o
-          "&nbsp;\r\n\r\n" >> .o))))
+      (-> (When
+           (-> (FS.Extension) (Is ".edn"))
+           (-> (| "=== \"Code\"\r\n\r\n" >> .o
+                  "    ```clojure linenums=\"1\"\r\n" >> .o
+                  "    --8<-- \"" >> .o name (getFilename samplePath "/") >> .o)
+               (| (FS.Filename) >> .o "\"\r\n" >> .o)
+               (| "    ```\r\n\r\n" >> .o
+                  "=== \"Output\"\r\n\r\n" >> .o
+                  "    ```\r\n" >> .o
+                  "    --8<-- \"" >> .o name (getFilename samplePath "/") >> .o)
+               (| (FS.Filename) >> .o ".log\"\r\n" >> .o
+                  "    ```\r\n" >> .o
+                  "&nbsp;\r\n\r\n" >> .o)))))))
 
    "--8<-- \"includes/license.md\"\r\n" >> .o
 


### PR DESCRIPTION
Save the output logs of the samples and inject them into the documentation, as a separate tab next to the sample code.