### PR TITLE
Remove boilerplate statements from the samples

### DIFF
--- a/docs/samples/blocks/General/ForEach/1.edn
+++ b/docs/samples/blocks/General/ForEach/1.edn
@@ -1,16 +1,9 @@
 ;; ForEach on a sequence: processes every element in seq order
-(defnode Main)
-(defloop test
-
-    [2 4 8 10]
-    (ForEach
-        (-> 
-            (| (Math.Multiply 10) 
-               (Log))  ;; => 20, 40, 80, 100
-            (| (Math.Multiply 100)
-               (Log))  ;; => 200, 400, 800, 1000
-        )
-    )
-)
-(schedule Main test)
-(run Main 1 1)
+[2 4 8 10]
+(ForEach
+ (->
+  (| (Math.Multiply 10)
+     (Log))  ;; => 20, 40, 80, 100
+  (| (Math.Multiply 100)
+     (Log))  ;; => 200, 400, 800, 1000
+  ))

--- a/docs/samples/blocks/General/ForEach/2.edn
+++ b/docs/samples/blocks/General/ForEach/2.edn
@@ -1,16 +1,9 @@
 ;; ForEach on a table: processes every key in alphabetic order
-(defnode Main)
-(defloop test
-
-    {"Name" "Universe" "Age" "13.8B Yrs"}
-    (ForEach ;; receives each key/value pair as a sequence in alphabetic order of key
-        (-> 
-            (| (Slice 0 1 1) ;; seq => every element starting from 0 till 0 => key of that pair
-               (Log))  ;; => ["Age"], ["Name"]
-            (| (Slice 1 2 1) ;; seq => every element starting from 1 till 1 => value of that pair
-               (Log))  ;; => ["13.8 B Yrs"], ["Universe"]
-        )
-    )
-)
-(schedule Main test)
-(run Main 1 1)
+{"Name" "Universe" "Age" "13.8B Yrs"}
+(ForEach ;; receives each key/value pair as a sequence in alphabetic order of key
+ (->
+  (| (Slice 0 1 1) ;; seq => every element starting from 0 till 0 => key of that pair
+     (Log))  ;; => ["Age"], ["Name"]
+  (| (Slice 1 2 1) ;; seq => every element starting from 1 till 1 => value of that pair
+     (Log))  ;; => ["13.8 B Yrs"], ["Universe"]
+  ))

--- a/docs/samples/blocks/General/Log/1.edn
+++ b/docs/samples/blocks/General/Log/1.edn
@@ -1,10 +1,4 @@
-(defloop main-chain
-    "I am a var" = .var
-    (* 2 4) (Log) ;; log previous block output
-    .var (Log)  ;; log a variable value
-    (+ 3 9) (Log :Prefix "String") ;; prefix a string to the logged output
-)
-
-(defnode root)
-(schedule root main-chain)
-(run root 1 1)
+"I am a var" = .var
+(* 2 4) (Log) ;; log previous block output
+.var (Log)  ;; log a variable value
+(+ 3 9) (Log :Prefix "String") ;; prefix a string to the logged output

--- a/docs/samples/blocks/General/Match/1.edn
+++ b/docs/samples/blocks/General/Match/1.edn
@@ -1,16 +1,9 @@
 ;; Multiple matches + nil case at end + passthrough
-(defloop main-chain
-    true
-    (Match
-        :Cases
-            [true (-> (Msg "Match found")) ;; match found so rest of the cases ignored
-            true (-> (Msg "Another match found")) ;; unreachable case statement
-            nil (-> (Msg "Any Match is OK"))] ;; unreachable case statement
-        :Passthrough 
-            true) ;; 
-    (Log) ;; print Match block's output => "true"
-)
-
-(defnode root)
-(schedule root main-chain)
-(run root 1 1)
+true
+(Match :Cases
+       [true (-> (Msg "Match found")) ;; match found so rest of the cases ignored
+        true (-> (Msg "Another match found")) ;; unreachable case statement
+        nil (-> (Msg "Any Match is OK"))] ;; unreachable case statement
+       :Passthrough
+       true)
+(Log) ;; print Match block's output => "true"

--- a/docs/samples/blocks/General/Match/2.edn
+++ b/docs/samples/blocks/General/Match/2.edn
@@ -1,16 +1,10 @@
 ;; Multiple matches + nil case at start + passthrough
-(defloop main-chain
-    true
-    (Match
-        :Cases
-            [nil (-> (Msg "Any Match is OK")) ;; nil case matches everything
-            true (-> (Msg "Match found")) ;; unreachable case statement
-            true (-> (Msg "Another match found"))] ;; unreachable case statement
-        :Passthrough 
-            true) ;; 
-    (Log) ;; print Match block's output => "true"
-)
-
-(defnode root)
-(schedule root main-chain)
-(run root 1 1)
+true
+(Match
+ :Cases
+ [nil (-> (Msg "Any Match is OK")) ;; nil case matches everything
+  true (-> (Msg "Match found")) ;; unreachable case statement
+  true (-> (Msg "Another match found"))] ;; unreachable case statement
+ :Passthrough
+ true)
+(Log) ;; print Match block's output => "true"

--- a/docs/samples/blocks/General/Match/3.edn
+++ b/docs/samples/blocks/General/Match/3.edn
@@ -1,16 +1,10 @@
 ;; No match + no nil case + passthrough
-(defloop main-chain
-    false
-    (Match
-        :Cases
-            [true (-> (Msg "Not a match")) ;; no match
-            true (-> (Msg "Not a match either"))] ;; no match
+false
+(Match
+ :Cases
+ [true (-> (Msg "Not a match")) ;; no match
+  true (-> (Msg "Not a match either"))] ;; no match
             ;; reached end of cases with no match found => no blocks activated
-        :Passthrough 
-            true) ;; input allowed to passthrough to Match block's output
-    (Log) ;; print Match block's output => "false"
-)
-
-(defnode root)
-(schedule root main-chain)
-(run root 1 1)
+ :Passthrough
+ true) ;; input allowed to passthrough to Match block's output
+(Log) ;; print Match block's output => "false"

--- a/docs/samples/blocks/General/Match/4.edn
+++ b/docs/samples/blocks/General/Match/4.edn
@@ -1,16 +1,10 @@
 ;; No match + nil case at end + passthrough
-(defloop main-chain
-    false
-    (Match
-        :Cases
-            [true (-> (Msg "Not a match"))  ;; no match
-            true (-> (Msg "Not a match either"))  ;; no match
-            nil (-> (Msg "Any Match is OK"))] ;; nil case matches everything
-        :Passthrough 
-            true) ;; 
-    (Log) ;; print Match block's output => "false"
-)
-
-(defnode root)
-(schedule root main-chain)
-(run root 1 1)
+false
+(Match
+ :Cases
+ [true (-> (Msg "Not a match"))  ;; no match
+  true (-> (Msg "Not a match either"))  ;; no match
+  nil (-> (Msg "Any Match is OK"))] ;; nil case matches everything
+ :Passthrough
+ true)
+(Log) ;; print Match block's output => "false"

--- a/docs/samples/blocks/General/Match/5.edn
+++ b/docs/samples/blocks/General/Match/5.edn
@@ -1,16 +1,10 @@
 ;; No match + nil case at end + no passthrough
-(defloop main-chain
-    false
-    (Match
-        :Cases
-            [true (-> (Msg "Not a match")) ;; no match
-            true (-> (Msg "Not a match either")) ;; no match
-            nil (-> true)] ;; nil case matches with everything => "true"
-        :Passthrough 
-            false) ;; matched case block's output routed to Match block's output 
-    (Log) ;; print Match block's output => "true"
-)
-
-(defnode root)
-(schedule root main-chain)
-(run root 1 1)
+false
+(Match
+ :Cases
+ [true (-> (Msg "Not a match")) ;; no match
+  true (-> (Msg "Not a match either")) ;; no match
+  nil (-> true)] ;; nil case matches with everything => "true"
+ :Passthrough
+ false) ;; matched case block's output routed to Match block's output
+(Log) ;; print Match block's output => "true"

--- a/docs/samples/blocks/General/Match/6.edn
+++ b/docs/samples/blocks/General/Match/6.edn
@@ -1,16 +1,10 @@
 ;; No match + no nil case + passthrough
-(defloop main-chain
-    false
-    (Match
-        :Cases
-            [true (-> (Msg "Not a match")) ;; no match found
-            true (-> (Msg "Not a match either"))] ;; no match found
+false
+(Match
+ :Cases
+ [true (-> (Msg "Not a match")) ;; no match found
+  true (-> (Msg "Not a match either"))] ;; no match found
             ;; reached end of cases, no matches, no nil case => no blocks activated
-        :Passthrough 
-            true) ;; input allowed to passthrough to Match block's output
-    (Log) ;; print Match block's output => "false"
-)
-
-(defnode root)
-(schedule root main-chain)
-(run root 1 1)
+ :Passthrough
+ true) ;; input allowed to passthrough to Match block's output
+(Log) ;; print Match block's output => "false"

--- a/docs/samples/blocks/General/Msg/1.edn
+++ b/docs/samples/blocks/General/Msg/1.edn
@@ -2,11 +2,5 @@
   (Msg a)  ;; print value of 1st arg passed
   (Msg b)) ;; print value of 2nd arg passed
 
-(defloop main-chain
-    (Msg "Hello World") ;; prints string
-    (msgblock "Bye" "Universe") ;; prints args passed
-)
-
-(defnode root)
-(schedule root main-chain)
-(run root 1 1)
+(Msg "Hello World") ;; prints string
+(msgblock "Bye" "Universe") ;; prints args passed

--- a/docs/samples/blocks/General/RTake/1.edn
+++ b/docs/samples/blocks/General/RTake/1.edn
@@ -1,13 +1,7 @@
-;; RTake
-(defnode Main)
-(defloop test
-    ;; RTake on sequences
-    [10 20 30 40] (RTake 1)
-    (Log) ;; => 30
-    [10 20 30 40] (RTake [0 1])
-    (Log) ;; => [40, 30]
+;; RTake on sequences
+[10 20 30 40] (RTake 1)
+(Log) ;; => 30
+[10 20 30 40] (RTake [0 1])
+(Log) ;; => [40, 30]
 
-    ;; RTake not valid on tables
-)
-(schedule Main test)
-(run Main 1 1)
+;; RTake not valid on tables

--- a/docs/samples/blocks/General/Slice/1.edn
+++ b/docs/samples/blocks/General/Slice/1.edn
@@ -1,19 +1,13 @@
-;; Slice
-(defnode Main)
-(defloop test
-    ;; Slice on strings
-    "Hello World" (Slice :From 1 :To 3 :Step 1)
-    (Log) ;; => "el"
-    "Hello World" (Slice 0 11 2)
-    (Log) ;; => "HloWrd"
+;; Slice on strings
+"Hello World" (Slice :From 1 :To 3 :Step 1)
+(Log) ;; => "el"
+"Hello World" (Slice 0 11 2)
+(Log) ;; => "HloWrd"
 
-    ;; Slice on sequences
-    [10 20 30 40 50 60 70 80 90] (Slice 1 3 1)
-    (Log) ;; => [20, 30]
-    [10 20 30 40 50 60 70 80 90] (Slice 0 7 3)
-    (Log) ;; => [10, 40, 70]
-    [10 20 30 40 50 60 70 80 90] (Slice -9 -2 3)
-    (Log) ;; => [10, 40, 70] : index -9 is same as 0, index -2 is same as 7
-)
-(schedule Main test)
-(run Main 1 1)
+;; Slice on sequences
+[10 20 30 40 50 60 70 80 90] (Slice 1 3 1)
+(Log) ;; => [20, 30]
+[10 20 30 40 50 60 70 80 90] (Slice 0 7 3)
+(Log) ;; => [10, 40, 70]
+[10 20 30 40 50 60 70 80 90] (Slice -9 -2 3)
+(Log) ;; => [10, 40, 70] : index -9 is same as 0, index -2 is same as 7

--- a/docs/samples/blocks/General/Sub/1.edn
+++ b/docs/samples/blocks/General/Sub/1.edn
@@ -1,34 +1,28 @@
 ;; Sub container block + nesting
-(defloop main-chain
-    (int 5) 
-    (Log "input to Sub1") ;; => 5
-    (Sub ;; Sub1: a set of block sequences
-        ;:Blocks
-        (->
-            (Math.Multiply 2)
-            (Assert.Is 10 true)
-            (Log "Sub1 inner block o/p | 5 * 2") ;; => 10
-        ))
-    (Log "Sub1 output => input to Sub2") ;; => 5
-    (Sub  ;; Sub2: another set of block sequences
-        ;:Blocks
-        (->
-            (Math.Multiply 3)
-            (Assert.Is 15 true)
-            (Log "Sub2 inner block o/p | 5 * 3") ;; => 15
-            (Log "input to nested-Sub") ;; => 15
-            (Sub ;; nesting of Sub blocks
-                ;:Blocks
-                (->
-                  (Math.Multiply 2)
-                  (Assert.Is 30 true)
-                  (Log "nested-Sub inner block o/p | (5 * 3) * 2") ;; => 30
-                ))
-            (Log "output from nested Sub") ;; => 15
-        ))
-    (Log "Sub2 output => output") ;; => 5
-)
-
-(defnode root)
-(schedule root main-chain)
-(run root 1 1)
+(int 5)
+(Log "input to Sub1") ;; => 5
+(Sub ;; Sub1: a set of block sequences
+ ;:Blocks
+ (->
+  (Math.Multiply 2)
+  (Assert.Is 10 true)
+  (Log "Sub1 inner block o/p | 5 * 2") ;; => 10
+  ))
+(Log "Sub1 output => input to Sub2") ;; => 5
+(Sub  ;; Sub2: another set of block sequences
+ ;:Blocks
+ (->
+  (Math.Multiply 3)
+  (Assert.Is 15 true)
+  (Log "Sub2 inner block o/p | 5 * 3") ;; => 15
+  (Log "input to nested-Sub") ;; => 15
+  (Sub ;; nesting of Sub blocks
+   ;:Blocks
+   (->
+    (Math.Multiply 2)
+    (Assert.Is 30 true)
+    (Log "nested-Sub inner block o/p | (5 * 3) * 2") ;; => 30
+    ))
+  (Log "output from nested Sub") ;; => 15
+  ))
+(Log "Sub2 output => output") ;; => 5

--- a/docs/samples/blocks/General/Sub/2.edn
+++ b/docs/samples/blocks/General/Sub/2.edn
@@ -1,25 +1,17 @@
-;; Using `Sub` and its alias `|`
-(defloop main-chain
 ;; Using `Sub`, with `->`
-    (int 5) 
-    (Sub (-> (Math.Multiply 2)
-             (Log))) ;; => 10
-    (Sub (-> (Math.Multiply 3)
-             (Log) ;; => 15
-             (Sub (-> (Math.Multiply 2)
-                      (Log))))) ;; => 30
+(int 5)
+(Sub (-> (Math.Multiply 2)
+         (Log))) ;; => 10
+(Sub (-> (Math.Multiply 3)
+         (Log) ;; => 15
+         (Sub (-> (Math.Multiply 2)
+                  (Log))))) ;; => 30
 
 ;; Using `|`, no need for `->`
-    (int 5) 
-    (| (Math.Multiply 2)
-       (Log)) ;; => 10
-    (| (Math.Multiply 3)
-       (Log) ;; => 15
-       (| (Math.Multiply 2)
-          (Log))) ;; => 30
-                
-)
-
-(defnode root)
-(schedule root main-chain)
-(run root 1 1)
+(int 5)
+(| (Math.Multiply 2)
+   (Log)) ;; => 10
+(| (Math.Multiply 3)
+   (Log) ;; => 15
+   (| (Math.Multiply 2)
+      (Log))) ;; => 30

--- a/docs/samples/blocks/General/Take/1.edn
+++ b/docs/samples/blocks/General/Take/1.edn
@@ -1,21 +1,15 @@
-;; Take
-(defnode Main)
-(defloop test
-    ;; Take on sequences
-    [10 20 30 40] (Take 1)
-    (Log) ;; => 20
-    [10 20 30 40] (Take [1 2])
-    (Log) ;; => [20, 30]
+;; Take on sequences
+[10 20 30 40] (Take 1)
+(Log) ;; => 20
+[10 20 30 40] (Take [1 2])
+(Log) ;; => [20, 30]
 
-    ;; Take on tables
-    {"Hello" 10 "World" 20} (Take "Hello")
-    (Log) ;; => 10
-    {"Hello" 10 "World" 20} (Take ["World" "Hello"])
-    (Log) ;; => [20, 10]
-    {"Hello" 10 "World" 20} (Take "Universe")
-    (Log) ;; => None
-    {:abc 10 :def 20} (Take "def")
-    (Log) ;; => 20
-)
-(schedule Main test)
-(run Main 1 1)
+;; Take on tables
+{"Hello" 10 "World" 20} (Take "Hello")
+(Log) ;; => 10
+{"Hello" 10 "World" 20} (Take ["World" "Hello"])
+(Log) ;; => [20, 10]
+{"Hello" 10 "World" 20} (Take "Universe")
+(Log) ;; => None
+{:abc 10 :def 20} (Take "def")
+(Log) ;; => 20


### PR DESCRIPTION
Remove the boilerplate `chain/loop` and `node` statements from the sample code of blocks.

Fixes #229 